### PR TITLE
fix: remap engine column names in trade_analyzer/data_handler.py (fix…

### DIFF
--- a/tests/test_report_smoke.py
+++ b/tests/test_report_smoke.py
@@ -1,0 +1,147 @@
+# tests/test_report_smoke.py
+"""
+Regression test for trade_analyzer/data_handler.py column name handling.
+
+Builds a minimal synthetic trade log CSV with the current engine column schema
+(EntryDate, ExitDate, EntryPrice, ExitPrice, ProfitPct, MAE_pct, MFE_pct,
+HoldDuration) and runs it through data_handler.clean_trades_data to verify
+no exception is raised.
+
+This catches future column rename drift between the engine and the analyzer.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from trade_analyzer.data_handler import clean_trades_data
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_engine_trade_log(n=20):
+    """
+    Build a synthetic trade log DataFrame using the CURRENT engine column schema.
+    These are the exact column names written by portfolio_simulations.py.
+    """
+    dates_entry = pd.bdate_range("2023-01-02", periods=n, freq="B")
+    dates_exit = dates_entry + pd.Timedelta(days=5)
+
+    return pd.DataFrame({
+        "Symbol":          ["TEST"] * n,
+        "Trade":           [f"Long {i+1}" for i in range(n)],
+        "EntryDate":       dates_entry.strftime("%Y-%m-%d"),
+        "ExitDate":        dates_exit.strftime("%Y-%m-%d"),
+        "EntryPrice":      np.random.uniform(90, 110, n).round(2),
+        "ExitPrice":       np.random.uniform(90, 115, n).round(2),
+        "Profit":          np.random.uniform(-500, 1000, n).round(2),
+        "ProfitPct":       np.random.uniform(-0.05, 0.10, n).round(4),
+        "Shares":          np.random.uniform(10, 100, n).round(1),
+        "is_win":          np.random.choice([0, 1], n),
+        "HoldDuration":    np.random.randint(1, 30, n),
+        "MAE_pct":         np.random.uniform(-0.10, 0, n).round(4),
+        "MFE_pct":         np.random.uniform(0, 0.15, n).round(4),
+        "ExitReason":      ["Strategy Exit"] * n,
+        "InitialRisk":     np.random.uniform(0.5, 2.0, n).round(2),
+        "RMultiple":       np.random.uniform(-2, 5, n).round(2),
+        "VolumeImpact_bps": [0.0] * n,
+    })
+
+
+# ---------------------------------------------------------------------------
+# TestReportSmoke
+# ---------------------------------------------------------------------------
+
+class TestReportSmoke:
+    """Smoke tests for the trade analyzer data handler with engine-format data."""
+
+    def test_clean_trades_data_no_exception(self):
+        """clean_trades_data must not raise on current engine column schema."""
+        df = _make_engine_trade_log(20)
+        # This should NOT raise ValueError about missing 'Date' column
+        result_df, summary = clean_trades_data(df, initial_equity=100_000.0)
+        assert result_df is not None
+        assert len(result_df) > 0
+
+    def test_date_column_remapped(self):
+        """EntryDate should be remapped to 'Date' for the analyzer."""
+        df = _make_engine_trade_log(10)
+        result_df, _ = clean_trades_data(df, initial_equity=100_000.0)
+        assert "Date" in result_df.columns
+        assert pd.api.types.is_datetime64_any_dtype(result_df["Date"])
+
+    def test_exit_date_column_remapped(self):
+        """ExitDate should be remapped to 'Ex. date' for the analyzer."""
+        df = _make_engine_trade_log(10)
+        result_df, _ = clean_trades_data(df, initial_equity=100_000.0)
+        assert "Ex. date" in result_df.columns
+        assert pd.api.types.is_datetime64_any_dtype(result_df["Ex. date"])
+
+    def test_price_columns_remapped(self):
+        """EntryPrice/ExitPrice should be remapped to Price/Ex. Price."""
+        df = _make_engine_trade_log(10)
+        result_df, _ = clean_trades_data(df, initial_equity=100_000.0)
+        assert "Price" in result_df.columns
+        assert "Ex. Price" in result_df.columns
+
+    def test_profit_pct_remapped(self):
+        """ProfitPct should be remapped to '% Profit'."""
+        df = _make_engine_trade_log(10)
+        result_df, _ = clean_trades_data(df, initial_equity=100_000.0)
+        assert "% Profit" in result_df.columns
+
+    def test_mae_mfe_remapped(self):
+        """MAE_pct/MFE_pct should be remapped to MAE/MFE."""
+        df = _make_engine_trade_log(10)
+        result_df, _ = clean_trades_data(df, initial_equity=100_000.0)
+        assert "MAE" in result_df.columns
+        assert "MFE" in result_df.columns
+
+    def test_hold_duration_remapped(self):
+        """HoldDuration should be remapped to '# bars'."""
+        df = _make_engine_trade_log(10)
+        result_df, _ = clean_trades_data(df, initial_equity=100_000.0)
+        assert "# bars" in result_df.columns
+
+    def test_equity_column_calculated(self):
+        """Equity column should be calculated from cumulative profit."""
+        df = _make_engine_trade_log(10)
+        result_df, _ = clean_trades_data(df, initial_equity=100_000.0)
+        assert "Equity" in result_df.columns
+        assert result_df["Equity"].notna().all()
+
+    def test_legacy_columns_still_work(self):
+        """If data already uses legacy column names (Date, Ex. date), it should still work."""
+        df = _make_engine_trade_log(10)
+        # Manually rename to legacy format before calling
+        df.rename(columns={
+            "EntryDate": "Date",
+            "ExitDate": "Ex. date",
+            "EntryPrice": "Price",
+            "ExitPrice": "Ex. Price",
+            "ProfitPct": "% Profit",
+            "MAE_pct": "MAE",
+            "MFE_pct": "MFE",
+            "HoldDuration": "# bars",
+        }, inplace=True)
+        result_df, _ = clean_trades_data(df, initial_equity=100_000.0)
+        assert result_df is not None
+        assert len(result_df) > 0
+
+    def test_all_engine_columns_present_after_cleaning(self):
+        """Core engine columns should survive the cleaning process."""
+        df = _make_engine_trade_log(15)
+        result_df, _ = clean_trades_data(df, initial_equity=100_000.0)
+        # These columns should exist (some remapped, some passed through)
+        for col in ["Symbol", "Profit", "Shares", "is_win", "ExitReason",
+                     "InitialRisk", "RMultiple"]:
+            assert col in result_df.columns, f"Missing column after cleaning: {col}"

--- a/trade_analyzer/data_handler.py
+++ b/trade_analyzer/data_handler.py
@@ -55,6 +55,24 @@ def clean_trades_data(trades_df: pd.DataFrame, initial_equity: float) -> Tuple[p
     #print("\n--- Attempting Data Cleaning ---")
     initial_load_count = len(trades_df)
 
+    # --- Column Remapping (engine v2 → legacy analyzer names) ---
+    # The backtester engine writes EntryDate/ExitDate/EntryPrice/ExitPrice/ProfitPct/etc.
+    # but the analyzer was built against an older column schema (Date/Ex. date/Price/etc.).
+    # This remapping bridges the two without touching every downstream reference.
+    _COLUMN_MAP = {
+        'EntryDate':    'Date',
+        'ExitDate':     'Ex. date',
+        'EntryPrice':   'Price',
+        'ExitPrice':    'Ex. Price',
+        'ProfitPct':    '% Profit',
+        'MAE_pct':      'MAE',
+        'MFE_pct':      'MFE',
+        'HoldDuration': '# bars',
+    }
+    for new_name, old_name in _COLUMN_MAP.items():
+        if new_name in trades_df.columns and old_name not in trades_df.columns:
+            trades_df.rename(columns={new_name: old_name}, inplace=True)
+
     # Convert dates
     if 'Date' in trades_df.columns:
         trades_df['Date'] = pd.to_datetime(trades_df['Date'], errors='coerce')


### PR DESCRIPTION
## What this PR does
Fixes the `ValueError: Required column 'Date' not found` crash in `report.py` by adding a column remapping block at the top of `clean_trades_data()` that translates the current engine column names to the legacy analyzer names.

## Tasks addressed
Fixes #39

## Changes made
| File | Change |
|------|--------|
| `trade_analyzer/data_handler.py` | Added column remapping block (EntryDate→Date, ExitDate→Ex. date, EntryPrice→Price, ExitPrice→Ex. Price, ProfitPct→% Profit, MAE_pct→MAE, MFE_pct→MFE, HoldDuration→# bars). Only remaps if the new name is present and the old name is not — legacy CSVs still work unchanged. |
| `tests/test_report_smoke.py` | Added — 10 regression tests that build a synthetic trade log with the current engine column schema and verify clean_trades_data handles it without exceptions. Tests cover all 8 remapped columns, equity calculation, legacy format backward compatibility, and engine column passthrough. |

## Tests
```
10 passed (test_report_smoke.py)