### PR TITLE
fix(config): default data_provider to yahoo instead of polygon

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,7 +16,7 @@ CONFIG = {
     # SECTION 1: DATA PROVIDER
     # ============================================================
     # Options: "polygon", "norgate", "yahoo", "csv"
-    "data_provider": "polygon",
+    "data_provider": "yahoo",
 
     # --- CSV Data Directory (only used when data_provider = "csv") ---
     # Path to the folder containing per-symbol CSV files.


### PR DESCRIPTION
## What & Why

The shipped default for \`data_provider\` was \`\"polygon\"\`, which requires a paid (or free-tier) API key to use. New users following the Quick Start hit an auth error immediately — before writing a single line of strategy code.

Yahoo Finance works out of the box with no API key. Defaulting to it removes the barrier for first-time users and matches the documented \"free to run\" promise in the README.

Closes #46.

## Changes

| File | Change |
|------|--------|
| \`config.py\` | \`\"data_provider\"\`: \`\"polygon\"\` → \`\"yahoo\"\` |

## PR Checklist

- [x] **Tests pass** — 11 passed, 0 failures (\`test_config_validator.py\`); full suite 701 passed
- [x] **CLAUDE.md updated** — not required; default value change only, no new keys or behaviour
- [x] **No hardcoded API keys** — not applicable
- [x] **No data artifacts** — not applicable
- [x] **Strategy naming** — not applicable
- [x] **Docstrings** — not applicable (config value change only)
- [x] **Dry run** — \`python main.py --dry-run\` unaffected; yahoo provider requires no key