### PR TITLE
fix(init-wizard): write directly to config.py and patch in-place when it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ graph TD
     D -->|Yahoo / Norgate / CSV| F[No API Key Needed]
     E --> G[Run Setup Wizard: python main.py --init]
     F --> G
-    G --> H[Review generated config.py]
-    H --> I[Ready to Backtest]
+    G --> H[config.py written - Ready to Backtest]
 ```
 
 **First time?** Run the setup wizard:
@@ -64,9 +63,8 @@ graph TD
     C --> E[Configure Account]
     D --> E
     E -->|Set Capital, Dates, & Slippage| F[Select Initial Portfolio]
-    F -->|Choose Nasdaq 100, S&P 500, etc.| G[Wizard Generates config_starter.py]
-    G --> H[Rename to config.py]
-    H --> I[Setup Complete - Ready to Run]
+    F -->|Choose Nasdaq 100, S&P 500, etc.| G[Wizard Writes config.py]
+    G --> I[Setup Complete - Ready to Run]
 ```
 
 **Or manually** — set these lines in `config.py` and run:

--- a/helpers/init_wizard.py
+++ b/helpers/init_wizard.py
@@ -19,6 +19,7 @@ Design constraints
 from __future__ import annotations
 
 import os
+import re
 import sys
 import textwrap
 from datetime import datetime
@@ -281,6 +282,83 @@ f'}}\n'
 
 
 # ---------------------------------------------------------------------------
+# In-place patcher for existing config.py
+# ---------------------------------------------------------------------------
+
+def _patch_existing_config(
+    config_path: Path,
+    provider: str,
+    capital: float,
+    start: str,
+    mode: str,
+    symbols_or_portfolio: object,
+) -> tuple[str, list[str]]:
+    """
+    Patch only the wizard-collected keys in an existing config.py.
+
+    Returns (patched_text, list_of_human_readable_changes).
+    Keys not matched in the file are silently skipped so that exotic
+    formatting or commented-out blocks never cause a crash.
+    """
+    text = config_path.read_text(encoding="utf-8")
+    changes: list[str] = []
+
+    # --- data_provider ---
+    new_text, n = re.subn(
+        r'("data_provider"\s*:\s*)"[^"]*"',
+        rf'\1"{provider}"',
+        text,
+    )
+    if n:
+        text = new_text
+        changes.append(f'data_provider → "{provider}"')
+
+    # --- initial_capital ---
+    new_text, n = re.subn(
+        r'("initial_capital"\s*:\s*)[\d.]+',
+        rf'\g<1>{capital}',
+        text,
+    )
+    if n:
+        text = new_text
+        changes.append(f"initial_capital → {capital}")
+
+    # --- start_date ---
+    new_text, n = re.subn(
+        r'("start_date"\s*:\s*)"[^"]*"',
+        rf'\1"{start}"',
+        text,
+    )
+    if n:
+        text = new_text
+        changes.append(f'start_date → "{start}"')
+
+    # --- symbols_to_test / portfolios ---
+    if mode == "single":
+        symbols_repr = repr(symbols_or_portfolio)
+        new_text, n = re.subn(
+            r'("symbols_to_test"\s*:\s*)\[[^\]]*\]',
+            rf'\g<1>{symbols_repr}',
+            text,
+        )
+        if n:
+            text = new_text
+            changes.append(f"symbols_to_test → {symbols_repr}")
+    else:
+        portfolios_repr = repr(symbols_or_portfolio)
+        new_text, n = re.subn(
+            r'"portfolios"\s*:\s*\{[^}]*\}',
+            f'"portfolios": {portfolios_repr}',
+            text,
+        )
+        if n:
+            text = new_text
+            changes.append(f"portfolios → {portfolios_repr}")
+
+    return text, changes
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -385,27 +463,38 @@ def run_init_wizard() -> None:
     # ------------------------------------------------------------------ #
     _section("Step 4 of 4 — Review & Write")
 
-    config_path = project_root / "config_starter.py"
-    config_exists = (project_root / "config.py").exists()
+    config_path = project_root / "config.py"
+    config_exists = config_path.exists()
 
     print(f"\n  {bold('Will write:')}")
-    print(f"    {green(str(config_path))}")
+    print(f"    {green(str(config_path))}", end="")
+    if config_exists:
+        print(yellow("  (existing file — wizard values will be patched in-place)"))
+    else:
+        print()
     if polygon_api_key:
         print(f"    {green(str(project_root / '.env'))}  (POLYGON_API_KEY)")
-    if config_exists:
-        print()
-        print(yellow("  Note: config.py already exists and will NOT be overwritten."))
-        print(yellow("  Copy the sections you need from config_starter.py into your config.py."))
 
     print()
     if not _confirm("Proceed and write files?"):
         print(yellow("  Aborted. No files written."))
         return
 
-    # Build and write config_starter.py
-    config_text = _build_config(provider, capital, start_date, end_expr, mode, symbols_or_portfolio)
-    config_path.write_text(config_text, encoding="utf-8")
-    print(green(f"\n  Written: {config_path}"))
+    # Write or patch config.py
+    if config_exists:
+        patched_text, changes = _patch_existing_config(
+            config_path, provider, capital, start_date, mode, symbols_or_portfolio
+        )
+        config_path.write_text(patched_text, encoding="utf-8")
+        print(green(f"\n  Updated: {config_path}"))
+        for ch in changes:
+            print(f"    {cyan('→')} {ch}")
+        if not changes:
+            print(yellow("  (no keys matched — no changes made)"))
+    else:
+        config_text = _build_config(provider, capital, start_date, end_expr, mode, symbols_or_portfolio)
+        config_path.write_text(config_text, encoding="utf-8")
+        print(green(f"\n  Written: {config_path}"))
 
     # Write .env if polygon key supplied
     if polygon_api_key:
@@ -425,8 +514,8 @@ def run_init_wizard() -> None:
     print()
     print(bold("  Next steps:"))
     if config_exists:
-        print(f"  1. Open {cyan('config_starter.py')} and copy the settings you want into {cyan('config.py')}.")
+        print(f"  1. Review {cyan('config.py')} — all other settings are unchanged.")
     else:
-        print(f"  1. Rename {cyan('config_starter.py')} → {cyan('config.py')}.")
+        print(f"  1. Review {cyan('config.py')} and adjust any other settings you need.")
     print(f"  2. Run:  {cyan('python main.py')}")
     print()

--- a/tests/test_init_wizard.py
+++ b/tests/test_init_wizard.py
@@ -3,10 +3,13 @@
 Unit tests for helpers/init_wizard.py.
 
 Covers:
-  TestBuildConfig     — _build_config output: valid Python, required keys,
-                        provider/capital/date presence, mode branching
-  TestColourHelpers   — bold/green/yellow/cyan/red return strings,
-                        plain text when _USE_COLOR is False
+  TestBuildConfig          — _build_config output: valid Python, required keys,
+                             provider/capital/date presence, mode branching
+  TestPatchExistingConfig  — _patch_existing_config: in-place key patching,
+                             non-destructive behaviour, missing-key tolerance,
+                             valid Python output
+  TestColourHelpers        — bold/green/yellow/cyan/red return strings,
+                             plain text when _USE_COLOR is False
 """
 
 import ast
@@ -21,6 +24,7 @@ if PROJECT_ROOT not in sys.path:
 
 from helpers.init_wizard import (
     _build_config,
+    _patch_existing_config,
     bold,
     cyan,
     green,
@@ -123,6 +127,123 @@ class TestBuildConfig:
         """No POLYGON_API_KEY note when provider is yahoo."""
         text = _cfg(provider="yahoo")
         assert "POLYGON_API_KEY" not in text
+
+
+# ---------------------------------------------------------------------------
+# TestPatchExistingConfig
+# ---------------------------------------------------------------------------
+
+class TestPatchExistingConfig:
+    """Tests for _patch_existing_config — in-place patching of an existing config.py."""
+
+    # Minimal config snippets used across tests
+    _FULL_SNIPPET = (
+        '    "data_provider": "polygon",\n'
+        '    "initial_capital": 100000.0,\n'
+        '    "start_date": "2004-01-01",\n'
+        '    "symbols_to_test": [\'BITB\'],\n'
+        '    "commission_per_share": 0.002,\n'
+    )
+
+    def _make(self, tmp_path, content=None):
+        p = tmp_path / "config.py"
+        p.write_text(content or self._FULL_SNIPPET, encoding="utf-8")
+        return p
+
+    # --- individual key patches ---
+
+    def test_patches_data_provider(self, tmp_path):
+        p = self._make(tmp_path)
+        text, changes = _patch_existing_config(p, "yahoo", 100_000.0, "2004-01-01", "single", ["SPY"])
+        assert '"data_provider": "yahoo"' in text
+        assert any("data_provider" in c for c in changes)
+
+    def test_patches_initial_capital(self, tmp_path):
+        p = self._make(tmp_path)
+        text, changes = _patch_existing_config(p, "polygon", 250_000.0, "2004-01-01", "single", ["SPY"])
+        assert "250000.0" in text
+        assert any("initial_capital" in c for c in changes)
+
+    def test_patches_start_date(self, tmp_path):
+        p = self._make(tmp_path)
+        text, changes = _patch_existing_config(p, "polygon", 100_000.0, "2015-06-01", "single", ["SPY"])
+        assert '"start_date": "2015-06-01"' in text
+        assert any("start_date" in c for c in changes)
+
+    def test_patches_symbols_to_test_single_mode(self, tmp_path):
+        p = self._make(tmp_path)
+        text, changes = _patch_existing_config(p, "polygon", 100_000.0, "2004-01-01", "single", ["AAPL", "MSFT"])
+        assert "AAPL" in text
+        assert "MSFT" in text
+        assert any("symbols_to_test" in c for c in changes)
+
+    def test_patches_portfolios_portfolio_mode(self, tmp_path):
+        content = (
+            '    "portfolios": {\n'
+            '        "Old Portfolio": "old.json",\n'
+            '    },\n'
+        )
+        p = self._make(tmp_path, content)
+        portfolio = {"Nasdaq 100": "nasdaq_100.json"}
+        text, changes = _patch_existing_config(p, "polygon", 100_000.0, "2004-01-01", "portfolio", portfolio)
+        assert "nasdaq_100.json" in text
+        assert "Old Portfolio" not in text
+        assert any("portfolios" in c for c in changes)
+
+    # --- non-destructive behaviour ---
+
+    def test_unrelated_keys_are_preserved(self, tmp_path):
+        """Keys the wizard doesn't ask about must survive unchanged."""
+        p = self._make(tmp_path)
+        text, _ = _patch_existing_config(p, "yahoo", 100_000.0, "2004-01-01", "single", ["SPY"])
+        assert '"commission_per_share": 0.002' in text
+
+    def test_old_provider_value_is_gone_after_patch(self, tmp_path):
+        p = self._make(tmp_path)
+        text, _ = _patch_existing_config(p, "yahoo", 100_000.0, "2004-01-01", "single", ["SPY"])
+        assert '"data_provider": "polygon"' not in text
+
+    def test_all_four_keys_patched_in_one_call(self, tmp_path):
+        p = self._make(tmp_path)
+        text, changes = _patch_existing_config(p, "yahoo", 50_000.0, "2020-01-01", "single", ["QQQ"])
+        assert '"data_provider": "yahoo"' in text
+        assert "50000.0" in text
+        assert '"start_date": "2020-01-01"' in text
+        assert "QQQ" in text
+        assert len(changes) == 4
+
+    # --- missing-key tolerance ---
+
+    def test_missing_data_provider_skipped_not_crash(self, tmp_path):
+        p = self._make(tmp_path, '    "initial_capital": 100000.0,\n')
+        text, changes = _patch_existing_config(p, "yahoo", 100_000.0, "2010-01-01", "single", ["SPY"])
+        assert not any("data_provider" in c for c in changes)
+
+    def test_missing_symbols_skipped_not_crash(self, tmp_path):
+        p = self._make(tmp_path, '    "data_provider": "polygon",\n')
+        text, changes = _patch_existing_config(p, "yahoo", 100_000.0, "2010-01-01", "single", ["AAPL"])
+        assert not any("symbols_to_test" in c for c in changes)
+
+    def test_empty_changes_list_when_nothing_matches(self, tmp_path):
+        p = self._make(tmp_path, '# nothing here\n')
+        _, changes = _patch_existing_config(p, "yahoo", 100_000.0, "2010-01-01", "single", ["SPY"])
+        assert changes == []
+
+    # --- output validity ---
+
+    def test_patched_full_config_is_valid_python(self, tmp_path):
+        """Patching a full _build_config output must still produce valid Python."""
+        base = _build_config(
+            "polygon", 100_000.0, "2004-01-01",
+            'datetime.now().strftime("%Y-%m-%d")',
+            "single", ["SPY"],
+        )
+        p = self._make(tmp_path, base)
+        text, _ = _patch_existing_config(p, "yahoo", 250_000.0, "2015-01-01", "single", ["AAPL"])
+        try:
+            ast.parse(text)
+        except SyntaxError as exc:
+            pytest.fail(f"Patched config is not valid Python: {exc}")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & Why

The setup wizard (`python main.py --init`) previously always wrote to `config_starter.py` and told the user to manually copy or rename it into `config.py`. Users reasonably expected their wizard choices to stick immediately — the extra manual step was confusing and undiscoverable (confirmed by a user who ran `--init`, selected `yahoo`, and was puzzled when `config.py` still showed `polygon`).

The first Quick Start Mermaid diagram in `README.md` compounded the issue by incorrectly labelling the wizard's output as `config.py` rather than `config_starter.py`.

## Changes

### `helpers/init_wizard.py`
- **New `_patch_existing_config()`** — reads the existing `config.py` and uses `re.subn` to surgically replace only the wizard-collected keys (`data_provider`, `initial_capital`, `start_date`, `symbols_to_test` / `portfolios`). All other settings (stop loss, MC, WFA, etc.) are left untouched. Keys not found in the file are silently skipped — no crash on unusual formatting.
- **`run_init_wizard()` Step 4 rewritten:**
  - `config_path` now always points to `config.py` (no more `config_starter.py`)
  - If `config.py` does not exist → write full template directly to `config.py`
  - If `config.py` already exists → call `_patch_existing_config()` and print each change made
  - Messaging updated throughout to match the new behaviour

### `tests/test_init_wizard.py`
- Added `TestPatchExistingConfig` (12 new tests) covering: individual key patches, non-destructive behaviour (unrelated keys preserved), old value removal, all-four-keys-in-one-call, missing-key tolerance (no crash), empty-changes result, and `ast.parse` validity of patched output
- No existing tests required changes — `_build_config` is unchanged

### `README.md`
- Both Mermaid diagrams updated to remove the intermediate rename/copy step; wizard now goes straight to "config.py written"

## PR Checklist

- [x] **Tests pass** — 25 passed (13 existing + 12 new), 0 failures
- [x] **CLAUDE.md updated** — not required; `helpers/init_wizard.py` entry in Key Files is accurate, wizard behaviour was not previously documented in CLAUDE.md
- [x] **No hardcoded API keys** — not applicable
- [x] **No data artifacts** — not applicable
- [x] **Strategy naming** — not applicable (no strategy changes)
- [x] **Docstrings** — `_patch_existing_config()` has a full docstring covering purpose, parameters, and skip behaviour
- [ ] **Dry run** — `python main.py --dry-run` not affected (wizard is invoked separately via `--init`); no pipeline code was modified