### PR TITLE
feat: add advanced position sizing framework (#66)

### DIFF
--- a/config.py
+++ b/config.py
@@ -402,7 +402,30 @@ CONFIG = {
     "strict_data_quality": False,
 
     # ============================================================
-    # SECTION 25: POINT-IN-TIME UNIVERSE PATHS
+    # SECTION 25: POSITION SIZING
+    # ============================================================
+    # Position sizing method: "fixed", "kelly", "vol_parity", "risk_parity"
+    "position_sizing_method": "fixed",
+
+    # Fixed method: % of equity per trade (used by "fixed" method)
+    # Already defined in SECTION 8, but listed here for reference
+    # "allocation_per_trade": 0.10,
+
+    # Kelly Criterion: fraction of full Kelly to use (conservative)
+    # Full Kelly can be very aggressive, so we use 25% by default
+    "kelly_fraction": 0.25,
+
+    # Volatility/Risk Parity: target risk per trade (2% of equity)
+    # This is the $ amount you're willing to lose if the trade hits your stop
+    "target_risk_per_trade": 0.02,
+
+    # Portfolio heat limit: max total $ risk across all open positions
+    # 0.10 = 10% of equity can be at risk simultaneously
+    # 1.0 = no limit (allow full portfolio risk)
+    "max_portfolio_heat": 0.10,
+
+    # ============================================================
+    # SECTION 26: POINT-IN-TIME UNIVERSE PATHS
     # ============================================================
     # Absolute paths to local clones of the PIT data repos.
     # Required when using "pit:nq100" or "pit:sp500" as a portfolio value.

--- a/helpers/config_validator.py
+++ b/helpers/config_validator.py
@@ -99,7 +99,12 @@ KNOWN_KEYS: set[str] = {
     "data_quality_checks",
     "data_quality_threshold",
     "strict_data_quality",
-    # SECTION 25: Point-in-Time Universe Paths
+    # SECTION 25: Position Sizing
+    "position_sizing_method",
+    "kelly_fraction",
+    "target_risk_per_trade",
+    "max_portfolio_heat",
+    # SECTION 26: Point-in-Time Universe Paths
     "nq100_pit_path",
     "sp500_pit_path",
     # S3

--- a/helpers/portfolio_simulations.py
+++ b/helpers/portfolio_simulations.py
@@ -228,18 +228,40 @@ def run_portfolio_simulation(portfolio_data, signals, initial_capital, allocatio
                 entry_exec_date = date
 
             if pd.isna(raw_entry_price): continue
-            
+
             entry_price = raw_entry_price * (1 + CONFIG['slippage_pct'])
-            
-            # Determine max capital to allocate for this single trade
-            capital_to_allocate = total_equity * allocation_pct
-            
-            # You cannot allocate more for the principal than your available cash
-            capital_to_allocate = min(capital_to_allocate, cash)
-            
-            if entry_price > 0 and capital_to_allocate > 0:
-                # Calculate ideal shares based on the capital allocation
-                shares = capital_to_allocate / entry_price
+
+            if entry_price > 0:
+                # --- POSITION SIZING ---
+                from helpers.position_sizing import calculate_position_size
+
+                sizing_method = CONFIG.get('position_sizing_method', 'fixed')
+
+                # Prepare kwargs for method-specific parameters
+                sizing_kwargs = {}
+
+                # For risk_parity: calculate stop distance if stop is set
+                if sizing_method == "risk_parity" and stop_config.get("type") != "none":
+                    # We'll calculate stop distance once we have the stop level
+                    # For now, pass None and let it fall back to ATR-based
+                    pass
+
+                # For kelly: historical stats not available during simulation
+                # Kelly will fall back to fixed in this implementation
+
+                shares = calculate_position_size(
+                    method=sizing_method,
+                    equity=total_equity,
+                    price=entry_price,
+                    symbol_data=df,
+                    config=CONFIG,
+                    **sizing_kwargs
+                )
+
+                # Cash constraint
+                capital_needed = shares * entry_price
+                if capital_needed > cash:
+                    shares = cash / entry_price
 
                 # --- VOLUME-BASED LIQUIDITY FILTER ---
                 max_pct_adv = CONFIG.get('max_pct_adv') or 0

--- a/helpers/portfolio_simulations.py
+++ b/helpers/portfolio_simulations.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 from config import CONFIG
 from .simulations import calculate_advanced_metrics
+from helpers.position_sizing import calculate_position_size, check_portfolio_heat
 
 def run_portfolio_simulation(portfolio_data, signals, initial_capital, allocation_pct, spy_df, vix_df, tnx_df, stop_config, delisting_dates=None):
     """
@@ -231,32 +232,59 @@ def run_portfolio_simulation(portfolio_data, signals, initial_capital, allocatio
 
             entry_price = raw_entry_price * (1 + CONFIG['slippage_pct'])
 
-            if entry_price > 0:
+            if entry_price > 0 and cash > 0:
                 # --- POSITION SIZING ---
-                from helpers.position_sizing import calculate_position_size
-
                 sizing_method = CONFIG.get('position_sizing_method', 'fixed')
-
-                # Prepare kwargs for method-specific parameters
                 sizing_kwargs = {}
 
-                # For risk_parity: calculate stop distance if stop is set
-                if sizing_method == "risk_parity" and stop_config.get("type") != "none":
-                    # We'll calculate stop distance once we have the stop level
-                    # For now, pass None and let it fall back to ATR-based
-                    pass
+                # For risk_parity: derive stop_distance_pct from the configured stop so
+                # sizing uses the actual stop rather than always falling back to 3x ATR.
+                if sizing_method == "risk_parity":
+                    stop_type = stop_config.get("type", "none")
+                    if stop_type == "percentage":
+                        sizing_kwargs["stop_distance_pct"] = stop_config.get("value", 0.05)
+                    elif stop_type == "atr":
+                        _day_before = prev_trading_dates[symbol].get(entry_exec_date)
+                        if _day_before is not None and _day_before in df.index and "ATR_14" in df.columns:
+                            _atr = df.loc[_day_before, 'ATR_14']
+                            _close = df.loc[_day_before, 'Close']
+                            if pd.notna(_atr) and pd.notna(_close) and _close > 0:
+                                sizing_kwargs["stop_distance_pct"] = (
+                                    _atr * stop_config.get("multiplier", 3.0)
+                                ) / _close
 
-                # For kelly: historical stats not available during simulation
-                # Kelly will fall back to fixed in this implementation
+                # For kelly: compute rolling stats from completed trades so sizing
+                # actually adapts to the strategy's live performance.
+                if sizing_method == "kelly" and len(trade_log) >= 10:
+                    _wins = [t for t in trade_log if t.get("is_win") == 1 and t.get("ProfitPct") is not None]
+                    _losses = [t for t in trade_log if t.get("is_win") == 0 and t.get("ProfitPct") is not None]
+                    if _wins and _losses:
+                        sizing_kwargs["win_rate"] = len(_wins) / len(trade_log)
+                        sizing_kwargs["avg_win"] = sum(t["ProfitPct"] for t in _wins) / len(_wins)
+                        sizing_kwargs["avg_loss"] = sum(abs(t["ProfitPct"]) for t in _losses) / len(_losses)
 
+                # Slice to current date to prevent look-ahead bias: vol_parity and
+                # risk_parity use .iloc[-1] on the passed DataFrame, so passing the
+                # full history would use a future ATR value on early simulation dates.
                 shares = calculate_position_size(
                     method=sizing_method,
                     equity=total_equity,
                     price=entry_price,
-                    symbol_data=df,
+                    symbol_data=df.loc[:date],
                     config=CONFIG,
                     **sizing_kwargs
                 )
+
+                # --- PORTFOLIO HEAT CHECK ---
+                # Compute the dollar risk this position adds. For methods with a
+                # known stop distance we use that; otherwise fall back to the
+                # target_risk_per_trade parameter (which is what vol/risk parity
+                # sized against anyway).
+                _stop_dist = sizing_kwargs.get("stop_distance_pct") or CONFIG.get("target_risk_per_trade", 0.02)
+                new_position_risk = shares * entry_price * _stop_dist
+                max_heat = CONFIG.get("max_portfolio_heat", 1.0)
+                if not check_portfolio_heat(positions, new_position_risk, total_equity, max_heat):
+                    continue
 
                 # Cash constraint
                 capital_needed = shares * entry_price
@@ -370,6 +398,7 @@ def run_portfolio_simulation(portfolio_data, signals, initial_capital, allocatio
                         'stop_loss_level': stop_loss_level,
                         'initial_stop_loss_level': stop_loss_level,
                         'entry_impact_bps': entry_impact_bps,
+                        'risk': new_position_risk,
                     }
                     cash -= total_cost
     

--- a/helpers/portfolio_simulations.py
+++ b/helpers/portfolio_simulations.py
@@ -272,6 +272,7 @@ def run_portfolio_simulation(portfolio_data, signals, initial_capital, allocatio
                     price=entry_price,
                     symbol_data=df.loc[:date],
                     config=CONFIG,
+                    allocation_pct=allocation_pct,  # honour the caller's allocation, not CONFIG only
                     **sizing_kwargs
                 )
 

--- a/helpers/position_sizing.py
+++ b/helpers/position_sizing.py
@@ -1,0 +1,257 @@
+"""helpers/position_sizing.py
+
+Position sizing algorithms for portfolio risk management.
+
+Supports 4 methods:
+1. Fixed % allocation (current default)
+2. Kelly Criterion (optimal growth)
+3. Volatility parity (inverse ATR)
+4. Risk parity (equal $ risk per position)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def calculate_position_size(
+    method: str,
+    equity: float,
+    price: float,
+    symbol_data: pd.DataFrame,
+    config: dict,
+    **kwargs
+) -> float:
+    """
+    Calculate position size (number of shares) based on selected method.
+
+    Parameters
+    ----------
+    method : str
+        Position sizing method: "fixed", "kelly", "vol_parity", "risk_parity"
+    equity : float
+        Current total portfolio equity
+    price : float
+        Entry price for this trade
+    symbol_data : pd.DataFrame
+        Recent OHLCV data for the symbol (must include ATR_14 for vol/risk parity)
+    config : dict
+        CONFIG dict with position sizing parameters
+    **kwargs : dict
+        Method-specific parameters:
+        - Kelly: win_rate, avg_win, avg_loss
+        - Risk parity: stop_distance_pct
+
+    Returns
+    -------
+    shares : float
+        Number of shares to buy (can be fractional)
+
+    Examples
+    --------
+    >>> # Fixed 10% allocation
+    >>> shares = calculate_position_size("fixed", 100000, 50.0, df, config)
+
+    >>> # Kelly Criterion
+    >>> shares = calculate_position_size(
+    ...     "kelly", 100000, 50.0, df, config,
+    ...     win_rate=0.55, avg_win=0.10, avg_loss=0.05
+    ... )
+    """
+    if method == "fixed":
+        return _fixed_allocation(equity, price, config)
+
+    elif method == "kelly":
+        return _kelly_criterion(equity, price, config, **kwargs)
+
+    elif method == "vol_parity":
+        return _volatility_parity(equity, price, symbol_data, config)
+
+    elif method == "risk_parity":
+        return _risk_parity(equity, price, symbol_data, config, **kwargs)
+
+    else:
+        logger.warning(
+            f"Unknown position sizing method '{method}'. Falling back to 'fixed'."
+        )
+        return _fixed_allocation(equity, price, config)
+
+
+def _fixed_allocation(equity: float, price: float, config: dict) -> float:
+    """
+    Fixed percentage allocation (current default behavior).
+
+    allocation_per_trade = 10% → 10% of equity allocated to each trade
+    """
+    allocation_pct = config.get("allocation_per_trade", 0.10)
+    capital_to_allocate = equity * allocation_pct
+    shares = capital_to_allocate / price if price > 0 else 0.0
+    return shares
+
+
+def _kelly_criterion(equity: float, price: float, config: dict, **kwargs) -> float:
+    """
+    Kelly Criterion position sizing for optimal growth.
+
+    Kelly fraction: f = (p * b - q) / b
+    where:
+    - p = win rate
+    - q = loss rate (1 - p)
+    - b = avg_win / avg_loss
+
+    We use a fractional Kelly to be conservative (default 25% of full Kelly).
+    """
+    # Extract historical stats from kwargs
+    win_rate = kwargs.get("win_rate")
+    avg_win = kwargs.get("avg_win")
+    avg_loss = kwargs.get("avg_loss")
+
+    # Validation
+    if win_rate is None or avg_win is None or avg_loss is None:
+        logger.warning(
+            "Kelly sizing requires win_rate, avg_win, avg_loss. Falling back to fixed."
+        )
+        return _fixed_allocation(equity, price, config)
+
+    if not (0 < win_rate < 1):
+        logger.warning(f"Invalid win_rate {win_rate}. Falling back to fixed.")
+        return _fixed_allocation(equity, price, config)
+
+    if avg_win <= 0 or avg_loss <= 0:
+        logger.warning(f"Invalid avg_win/avg_loss ({avg_win}/{avg_loss}). Falling back to fixed.")
+        return _fixed_allocation(equity, price, config)
+
+    # Calculate Kelly fraction
+    b = avg_win / avg_loss
+    p = win_rate
+    q = 1.0 - p
+
+    kelly_f = (p * b - q) / b
+
+    # Kelly can be negative (strategy has negative edge) or > 1 (very high edge)
+    # Clamp to [0, 1] for safety
+    kelly_f = max(0.0, min(1.0, kelly_f))
+
+    # Apply fractional Kelly (default 25% for safety)
+    kelly_fraction = config.get("kelly_fraction", 0.25)
+    f = kelly_f * kelly_fraction
+
+    capital_to_allocate = equity * f
+    shares = capital_to_allocate / price if price > 0 else 0.0
+
+    return shares
+
+
+def _volatility_parity(equity: float, price: float, symbol_data: pd.DataFrame, config: dict) -> float:
+    """
+    Volatility parity sizing: allocate inversely proportional to volatility.
+
+    Lower volatility symbols get larger positions, higher volatility get smaller.
+    Target risk per trade is controlled by config.
+
+    Uses ATR as a proxy for volatility.
+    """
+    if "ATR_14" not in symbol_data.columns or len(symbol_data) == 0:
+        logger.warning("ATR_14 not available for vol parity sizing. Falling back to fixed.")
+        return _fixed_allocation(equity, price, config)
+
+    atr = symbol_data["ATR_14"].iloc[-1]
+
+    if pd.isna(atr) or atr <= 0:
+        logger.warning("Invalid ATR value for vol parity sizing. Falling back to fixed.")
+        return _fixed_allocation(equity, price, config)
+
+    atr_pct = atr / price if price > 0 else 0.0
+
+    if atr_pct <= 0:
+        return _fixed_allocation(equity, price, config)
+
+    # target_risk_per_trade = 2% means we want to risk 2% of equity on this trade
+    # shares = (equity * target_risk) / (price * atr_pct)
+    target_risk = config.get("target_risk_per_trade", 0.02)
+    shares = (equity * target_risk) / (price * atr_pct) if atr_pct > 0 else 0.0
+
+    return shares
+
+
+def _risk_parity(equity: float, price: float, symbol_data: pd.DataFrame, config: dict, **kwargs) -> float:
+    """
+    Risk parity sizing: equal $ risk per position.
+
+    Requires a stop loss distance. Position size is calculated so that
+    hitting the stop would lose `target_risk_per_trade` of equity.
+
+    shares = (equity * target_risk) / (price * stop_distance_pct)
+    """
+    stop_distance_pct = kwargs.get("stop_distance_pct")
+
+    if stop_distance_pct is None or stop_distance_pct <= 0:
+        # Fallback: use ATR-based stop if available
+        if "ATR_14" in symbol_data.columns and len(symbol_data) > 0:
+            atr = symbol_data["ATR_14"].iloc[-1]
+            if pd.notna(atr) and atr > 0:
+                # Default: 3x ATR stop
+                stop_distance_pct = (atr * 3.0) / price
+            else:
+                logger.warning("No valid stop distance for risk parity sizing. Falling back to fixed.")
+                return _fixed_allocation(equity, price, config)
+        else:
+            logger.warning("No stop distance or ATR for risk parity sizing. Falling back to fixed.")
+            return _fixed_allocation(equity, price, config)
+
+    target_risk = config.get("target_risk_per_trade", 0.02)
+    shares = (equity * target_risk) / (price * stop_distance_pct) if stop_distance_pct > 0 else 0.0
+
+    return shares
+
+
+def check_portfolio_heat(positions: dict, new_position_risk: float, equity: float, max_heat: float) -> bool:
+    """
+    Check if adding a new position would exceed maximum portfolio heat.
+
+    Portfolio heat = total $ risk across all open positions / equity
+
+    Parameters
+    ----------
+    positions : dict
+        Currently open positions (from portfolio_simulations.py)
+    new_position_risk : float
+        $ risk for the new position being considered
+    equity : float
+        Current total portfolio equity
+    max_heat : float
+        Maximum allowed portfolio heat (e.g., 0.10 = 10%)
+
+    Returns
+    -------
+    bool
+        True if adding the position is allowed, False if it would exceed max_heat
+
+    Examples
+    --------
+    >>> positions = {"AAPL": {"risk": 500}, "MSFT": {"risk": 300}}
+    >>> check_portfolio_heat(positions, 400, 100000, 0.02)  # 2% max heat
+    False  # (500 + 300 + 400) / 100000 = 0.012 > 0.02? No, allowed
+    """
+    # Sum current risk across all positions
+    current_risk = sum(pos.get("risk", 0.0) for pos in positions.values())
+
+    total_risk = current_risk + new_position_risk
+
+    heat = total_risk / equity if equity > 0 else 0.0
+
+    if heat > max_heat:
+        logger.debug(
+            f"Portfolio heat check: {heat:.2%} > {max_heat:.2%}. Trade rejected."
+        )
+        return False
+
+    return True

--- a/helpers/position_sizing.py
+++ b/helpers/position_sizing.py
@@ -28,6 +28,7 @@ def calculate_position_size(
     price: float,
     symbol_data: pd.DataFrame,
     config: dict,
+    allocation_pct: float | None = None,
     **kwargs
 ) -> float:
     """
@@ -67,7 +68,7 @@ def calculate_position_size(
     ... )
     """
     if method == "fixed":
-        return _fixed_allocation(equity, price, config)
+        return _fixed_allocation(equity, price, config, allocation_pct=allocation_pct)
 
     elif method == "kelly":
         return _kelly_criterion(equity, price, config, **kwargs)
@@ -82,16 +83,22 @@ def calculate_position_size(
         logger.warning(
             f"Unknown position sizing method '{method}'. Falling back to 'fixed'."
         )
-        return _fixed_allocation(equity, price, config)
+        return _fixed_allocation(equity, price, config, allocation_pct=allocation_pct)
 
 
-def _fixed_allocation(equity: float, price: float, config: dict) -> float:
+def _fixed_allocation(equity: float, price: float, config: dict, allocation_pct: float | None = None) -> float:
     """
     Fixed percentage allocation (current default behavior).
 
     allocation_per_trade = 10% → 10% of equity allocated to each trade
+
+    When the caller passes an explicit ``allocation_pct`` (i.e. the engine's
+    ``allocation_pct`` parameter), it takes precedence over the config value so
+    the function honours the argument it was given rather than silently reading
+    CONFIG. Falls back to ``config["allocation_per_trade"]`` when not provided.
     """
-    allocation_pct = config.get("allocation_per_trade", 0.10)
+    if allocation_pct is None:
+        allocation_pct = config.get("allocation_per_trade", 0.10)
     capital_to_allocate = equity * allocation_pct
     shares = capital_to_allocate / price if price > 0 else 0.0
     return shares

--- a/tests/test_position_sizing.py
+++ b/tests/test_position_sizing.py
@@ -286,11 +286,11 @@ class TestPortfolioHeat:
         result = check_portfolio_heat(positions, 1000, 100000, 0.02)  # 1% heat, 2% max
         assert result is True
 
-    def test_zero_equity_returns_false(self):
-        """Zero equity returns False (safety guard)."""
+    def test_zero_equity_returns_true(self):
+        """Zero equity: heat defaults to 0.0 (division guarded), so trade is allowed."""
         positions = {}
         result = check_portfolio_heat(positions, 100, 0, 0.10)
-        assert result is True  # Actually, with 0 equity, heat = 0.0 / 0 = 0, which is <= max_heat
+        assert result is True
 
     def test_max_heat_100pct_allows_all(self):
         """max_heat=1.0 (100%) allows all trades."""
@@ -309,3 +309,85 @@ class TestPortfolioHeat:
         # Only MSFT contributes to heat
         result = check_portfolio_heat(positions, 1000, 100000, 0.02)  # (500+1000)/100000 = 1.5%
         assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for bugs fixed after initial implementation
+# ---------------------------------------------------------------------------
+
+class TestLookAheadBiasSlice:
+    """vol_parity and risk_parity must not see future ATR values."""
+
+    def test_vol_parity_uses_last_row_of_slice_not_full_history(self):
+        """Slicing symbol_data to current date prevents using a future ATR."""
+        config = {"target_risk_per_trade": 0.02}
+        dates = pd.date_range("2020-01-01", periods=5, freq="D")
+        # Early ATR is 1.0; last (future) ATR is 100.0
+        df = pd.DataFrame({"ATR_14": [1.0, 1.0, 1.0, 1.0, 100.0]}, index=dates)
+
+        # Slice to the 4th bar (simulating current date = dates[3])
+        current_slice = df.loc[: dates[3]]
+        shares_correct = _volatility_parity(100000, 50.0, current_slice, config)
+
+        # Using full history (the bug) would read ATR=100 from the last bar
+        shares_biased = _volatility_parity(100000, 50.0, df, config)
+
+        # Correct sizing uses ATR=1.0 → much larger position than biased ATR=100.0
+        assert shares_correct > shares_biased
+
+
+class TestKellyRollingStats:
+    """Kelly must produce non-fixed sizing once trade history is available."""
+
+    def test_kelly_with_stats_differs_from_fixed(self):
+        """Kelly with win_rate/avg_win/avg_loss produces a different size than fixed."""
+        config = {"allocation_per_trade": 0.10, "kelly_fraction": 0.25}
+        dates = pd.date_range("2020-01-01", periods=5, freq="D")
+        df = pd.DataFrame({"ATR_14": [2.0] * 5}, index=dates)
+
+        shares_fixed = calculate_position_size("fixed", 100000, 50.0, df, config)
+        # win_rate=0.65, R:R=2:1 → full Kelly = 0.475 → fractional = 0.11875 ≠ 0.10 fixed
+        shares_kelly = calculate_position_size(
+            "kelly", 100000, 50.0, df, config,
+            win_rate=0.65, avg_win=0.08, avg_loss=0.04,
+        )
+        assert shares_kelly != shares_fixed
+        assert shares_kelly == pytest.approx(237.5)
+
+    def test_kelly_falls_back_when_fewer_than_10_trades(self):
+        """Kelly falls back to fixed when insufficient trade history is passed."""
+        config = {"allocation_per_trade": 0.10, "kelly_fraction": 0.25}
+        dates = pd.date_range("2020-01-01", periods=5, freq="D")
+        df = pd.DataFrame({"ATR_14": [2.0] * 5}, index=dates)
+
+        # No kwargs → missing win_rate/avg_win/avg_loss → fallback to fixed
+        shares = calculate_position_size("kelly", 100000, 50.0, df, config)
+        assert shares == pytest.approx(200.0)
+
+
+class TestRiskParityStopDistance:
+    """risk_parity must use the configured stop distance, not always ATR fallback."""
+
+    def test_percentage_stop_uses_config_value(self):
+        """stop_distance_pct derived from percentage stop matches direct call."""
+        config = {"target_risk_per_trade": 0.02}
+        df = pd.DataFrame({"ATR_14": [2.0]}, index=[pd.Timestamp("2020-01-01")])
+
+        # Direct call with explicit stop distance = 5%
+        shares_direct = _risk_parity(100000, 50.0, df, config, stop_distance_pct=0.05)
+        # shares = (100000 * 0.02) / (50.0 * 0.05) = 800
+        assert shares_direct == pytest.approx(800.0)
+
+    def test_atr_fallback_used_when_no_stop_distance(self):
+        """When stop_distance_pct is absent, 3x ATR fallback is used."""
+        config = {"target_risk_per_trade": 0.02}
+        df = pd.DataFrame({"ATR_14": [2.0]}, index=[pd.Timestamp("2020-01-01")])
+
+        shares_fallback = _risk_parity(100000, 50.0, df, config)
+        # stop_distance = (2.0 * 3.0) / 50.0 = 0.12
+        # shares = (100000 * 0.02) / (50.0 * 0.12) ≈ 333.33
+        assert shares_fallback == pytest.approx(333.33, rel=0.01)
+
+        # Explicit stop of 5% must produce a different (larger) result than 12% fallback
+        shares_explicit = _risk_parity(100000, 50.0, df, config, stop_distance_pct=0.05)
+        assert shares_explicit > shares_fallback

--- a/tests/test_position_sizing.py
+++ b/tests/test_position_sizing.py
@@ -1,0 +1,311 @@
+"""tests/test_position_sizing.py
+
+Tests for position sizing algorithms (helpers/position_sizing.py).
+"""
+
+import pytest
+import pandas as pd
+import numpy as np
+from helpers.position_sizing import (
+    calculate_position_size,
+    check_portfolio_heat,
+    _fixed_allocation,
+    _kelly_criterion,
+    _volatility_parity,
+    _risk_parity,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test calculate_position_size (main entry point)
+# ---------------------------------------------------------------------------
+
+class TestCalculatePositionSize:
+    """Test the main calculate_position_size function."""
+
+    def test_unknown_method_falls_back_to_fixed(self):
+        """Unknown method logs warning and falls back to fixed allocation."""
+        dates = pd.date_range("2020-01-01", periods=10, freq="D")
+        df = pd.DataFrame({"Close": range(100, 110), "ATR_14": [2.0] * 10}, index=dates)
+        config = {"allocation_per_trade": 0.10}
+
+        shares = calculate_position_size("unknown_method", 100000, 50.0, df, config)
+
+        # Should fall back to fixed: (100000 * 0.10) / 50 = 200
+        assert shares == pytest.approx(200.0)
+
+    def test_routes_to_correct_method(self):
+        """Each method routes to the correct implementation."""
+        dates = pd.date_range("2020-01-01", periods=10, freq="D")
+        df = pd.DataFrame({"Close": range(100, 110), "ATR_14": [2.0] * 10}, index=dates)
+        config = {"allocation_per_trade": 0.10, "target_risk_per_trade": 0.02, "kelly_fraction": 0.25}
+
+        # Fixed
+        shares_fixed = calculate_position_size("fixed", 100000, 50.0, df, config)
+        assert shares_fixed == pytest.approx(200.0)
+
+        # Vol parity
+        shares_vol = calculate_position_size("vol_parity", 100000, 50.0, df, config)
+        assert shares_vol > 0
+
+        # Risk parity
+        shares_risk = calculate_position_size("risk_parity", 100000, 50.0, df, config, stop_distance_pct=0.05)
+        assert shares_risk > 0
+
+        # Kelly (will fall back to fixed without historical stats)
+        shares_kelly = calculate_position_size("kelly", 100000, 50.0, df, config)
+        assert shares_kelly > 0
+
+
+# ---------------------------------------------------------------------------
+# Test _fixed_allocation
+# ---------------------------------------------------------------------------
+
+class TestFixedAllocation:
+    """Test fixed percentage allocation."""
+
+    def test_calculates_correct_shares(self):
+        """Fixed allocation: shares = (equity * pct) / price."""
+        config = {"allocation_per_trade": 0.10}
+        shares = _fixed_allocation(100000, 50.0, config)
+        assert shares == pytest.approx(200.0)  # (100000 * 0.10) / 50
+
+    def test_different_allocation_percentages(self):
+        """Different allocation percentages produce correct results."""
+        config_5pct = {"allocation_per_trade": 0.05}
+        config_20pct = {"allocation_per_trade": 0.20}
+
+        shares_5 = _fixed_allocation(100000, 50.0, config_5pct)
+        shares_20 = _fixed_allocation(100000, 50.0, config_20pct)
+
+        assert shares_5 == pytest.approx(100.0)
+        assert shares_20 == pytest.approx(400.0)
+
+    def test_zero_price_returns_zero(self):
+        """Zero price returns zero shares."""
+        config = {"allocation_per_trade": 0.10}
+        shares = _fixed_allocation(100000, 0.0, config)
+        assert shares == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Test _kelly_criterion
+# ---------------------------------------------------------------------------
+
+class TestKellyCriterion:
+    """Test Kelly Criterion position sizing."""
+
+    def test_positive_edge_returns_positive_shares(self):
+        """Kelly with positive edge (55% win rate, 2:1 R:R) returns shares."""
+        config = {"kelly_fraction": 1.0}  # Full Kelly for testing
+        shares = _kelly_criterion(
+            100000, 50.0, config,
+            win_rate=0.55, avg_win=0.10, avg_loss=0.05
+        )
+        assert shares > 0
+
+    def test_negative_edge_returns_zero(self):
+        """Kelly with negative edge (40% win rate, 1:1 R:R) returns zero shares."""
+        config = {"kelly_fraction": 1.0}
+        shares = _kelly_criterion(
+            100000, 50.0, config,
+            win_rate=0.40, avg_win=0.05, avg_loss=0.05
+        )
+        assert shares == 0.0  # Negative Kelly clamped to 0
+
+    def test_fractional_kelly_reduces_bet_size(self):
+        """Fractional Kelly (25%) is more conservative than full Kelly."""
+        full_kelly_config = {"kelly_fraction": 1.0}
+        frac_kelly_config = {"kelly_fraction": 0.25}
+
+        shares_full = _kelly_criterion(
+            100000, 50.0, full_kelly_config,
+            win_rate=0.55, avg_win=0.10, avg_loss=0.05
+        )
+        shares_frac = _kelly_criterion(
+            100000, 50.0, frac_kelly_config,
+            win_rate=0.55, avg_win=0.10, avg_loss=0.05
+        )
+
+        assert shares_frac < shares_full
+        assert shares_frac == pytest.approx(shares_full * 0.25)
+
+    def test_missing_parameters_falls_back_to_fixed(self):
+        """Missing win_rate/avg_win/avg_loss falls back to fixed allocation."""
+        config = {"allocation_per_trade": 0.10, "kelly_fraction": 0.25}
+
+        # Missing win_rate
+        shares = _kelly_criterion(100000, 50.0, config, avg_win=0.10, avg_loss=0.05)
+        assert shares == pytest.approx(200.0)  # Fixed fallback
+
+        # Missing avg_win
+        shares = _kelly_criterion(100000, 50.0, config, win_rate=0.55, avg_loss=0.05)
+        assert shares == pytest.approx(200.0)
+
+    def test_invalid_win_rate_falls_back(self):
+        """Invalid win_rate (< 0 or > 1) falls back to fixed."""
+        config = {"allocation_per_trade": 0.10, "kelly_fraction": 0.25}
+
+        shares = _kelly_criterion(
+            100000, 50.0, config,
+            win_rate=1.5, avg_win=0.10, avg_loss=0.05
+        )
+        assert shares == pytest.approx(200.0)
+
+
+# ---------------------------------------------------------------------------
+# Test _volatility_parity
+# ---------------------------------------------------------------------------
+
+class TestVolatilityParity:
+    """Test volatility parity position sizing."""
+
+    def test_higher_atr_yields_smaller_position(self):
+        """Higher volatility (ATR) results in smaller position size."""
+        config = {"target_risk_per_trade": 0.02}
+
+        low_vol_df = pd.DataFrame({"ATR_14": [1.0]}, index=[pd.Timestamp("2020-01-01")])
+        high_vol_df = pd.DataFrame({"ATR_14": [5.0]}, index=[pd.Timestamp("2020-01-01")])
+
+        shares_low = _volatility_parity(100000, 50.0, low_vol_df, config)
+        shares_high = _volatility_parity(100000, 50.0, high_vol_df, config)
+
+        assert shares_low > shares_high
+
+    def test_calculates_correct_shares(self):
+        """Vol parity formula: shares = (equity * target_risk) / (price * atr_pct)."""
+        config = {"target_risk_per_trade": 0.02}
+        df = pd.DataFrame({"ATR_14": [2.0]}, index=[pd.Timestamp("2020-01-01")])
+
+        shares = _volatility_parity(100000, 50.0, df, config)
+
+        # atr_pct = 2.0 / 50.0 = 0.04
+        # shares = (100000 * 0.02) / (50.0 * 0.04) = 2000 / 2.0 = 1000
+        assert shares == pytest.approx(1000.0)
+
+    def test_missing_atr_falls_back_to_fixed(self):
+        """Missing ATR_14 column falls back to fixed allocation."""
+        config = {"allocation_per_trade": 0.10, "target_risk_per_trade": 0.02}
+        df = pd.DataFrame({"Close": [50.0]}, index=[pd.Timestamp("2020-01-01")])  # No ATR
+
+        shares = _volatility_parity(100000, 50.0, df, config)
+        assert shares == pytest.approx(200.0)  # Fixed fallback
+
+    def test_zero_atr_falls_back_to_fixed(self):
+        """Zero or NaN ATR falls back to fixed allocation."""
+        config = {"allocation_per_trade": 0.10, "target_risk_per_trade": 0.02}
+        df = pd.DataFrame({"ATR_14": [0.0]}, index=[pd.Timestamp("2020-01-01")])
+
+        shares = _volatility_parity(100000, 50.0, df, config)
+        assert shares == pytest.approx(200.0)
+
+
+# ---------------------------------------------------------------------------
+# Test _risk_parity
+# ---------------------------------------------------------------------------
+
+class TestRiskParity:
+    """Test risk parity position sizing."""
+
+    def test_wider_stop_yields_smaller_position(self):
+        """Wider stop distance results in smaller position size."""
+        config = {"target_risk_per_trade": 0.02}
+        df = pd.DataFrame({"ATR_14": [2.0]}, index=[pd.Timestamp("2020-01-01")])
+
+        shares_tight = _risk_parity(100000, 50.0, df, config, stop_distance_pct=0.02)
+        shares_wide = _risk_parity(100000, 50.0, df, config, stop_distance_pct=0.10)
+
+        assert shares_tight > shares_wide
+
+    def test_calculates_correct_shares(self):
+        """Risk parity formula: shares = (equity * target_risk) / (price * stop_distance)."""
+        config = {"target_risk_per_trade": 0.02}
+        df = pd.DataFrame({"ATR_14": [2.0]}, index=[pd.Timestamp("2020-01-01")])
+
+        shares = _risk_parity(100000, 50.0, df, config, stop_distance_pct=0.05)
+
+        # shares = (100000 * 0.02) / (50.0 * 0.05) = 2000 / 2.5 = 800
+        assert shares == pytest.approx(800.0)
+
+    def test_fallback_to_atr_stop_when_no_stop_distance(self):
+        """When stop_distance_pct not provided, uses 3x ATR as stop."""
+        config = {"target_risk_per_trade": 0.02}
+        df = pd.DataFrame({"ATR_14": [2.0]}, index=[pd.Timestamp("2020-01-01")])
+
+        shares = _risk_parity(100000, 50.0, df, config)
+
+        # stop_distance_pct = (2.0 * 3.0) / 50.0 = 0.12
+        # shares = (100000 * 0.02) / (50.0 * 0.12) = 2000 / 6.0 = 333.33
+        assert shares == pytest.approx(333.33, rel=0.01)
+
+    def test_missing_stop_and_atr_falls_back_to_fixed(self):
+        """Missing both stop distance and ATR falls back to fixed."""
+        config = {"allocation_per_trade": 0.10, "target_risk_per_trade": 0.02}
+        df = pd.DataFrame({"Close": [50.0]}, index=[pd.Timestamp("2020-01-01")])  # No ATR
+
+        shares = _risk_parity(100000, 50.0, df, config)
+        assert shares == pytest.approx(200.0)
+
+
+# ---------------------------------------------------------------------------
+# Test check_portfolio_heat
+# ---------------------------------------------------------------------------
+
+class TestPortfolioHeat:
+    """Test portfolio heat limit enforcement."""
+
+    def test_allows_trade_when_under_limit(self):
+        """Trade is allowed when total heat remains under max_heat."""
+        positions = {
+            "AAPL": {"risk": 500},
+            "MSFT": {"risk": 300},
+        }
+        # Current heat: (500 + 300) / 100000 = 0.008 (0.8%)
+        # New position: 200
+        # Total heat: (800 + 200) / 100000 = 0.01 (1.0%)
+        # Max heat: 2%
+        result = check_portfolio_heat(positions, 200, 100000, 0.02)
+        assert result is True
+
+    def test_rejects_trade_when_over_limit(self):
+        """Trade is rejected when total heat would exceed max_heat."""
+        positions = {
+            "AAPL": {"risk": 1500},
+            "MSFT": {"risk": 1500},
+        }
+        # Current heat: 3000 / 100000 = 0.03 (3%)
+        # New position: 500
+        # Total heat: 3500 / 100000 = 0.035 (3.5%)
+        # Max heat: 3%
+        result = check_portfolio_heat(positions, 500, 100000, 0.03)
+        assert result is False
+
+    def test_empty_positions_allows_first_trade(self):
+        """Empty positions dict allows first trade under max_heat."""
+        positions = {}
+        result = check_portfolio_heat(positions, 1000, 100000, 0.02)  # 1% heat, 2% max
+        assert result is True
+
+    def test_zero_equity_returns_false(self):
+        """Zero equity returns False (safety guard)."""
+        positions = {}
+        result = check_portfolio_heat(positions, 100, 0, 0.10)
+        assert result is True  # Actually, with 0 equity, heat = 0.0 / 0 = 0, which is <= max_heat
+
+    def test_max_heat_100pct_allows_all(self):
+        """max_heat=1.0 (100%) allows all trades."""
+        positions = {
+            "SYM1": {"risk": 50000},  # 50% of equity
+        }
+        result = check_portfolio_heat(positions, 40000, 100000, 1.0)  # 90% total heat
+        assert result is True
+
+    def test_positions_without_risk_key_treated_as_zero(self):
+        """Positions without 'risk' key are treated as 0 risk."""
+        positions = {
+            "AAPL": {},  # No risk key
+            "MSFT": {"risk": 500},
+        }
+        # Only MSFT contributes to heat
+        result = check_portfolio_heat(positions, 1000, 100000, 0.02)  # (500+1000)/100000 = 1.5%
+        assert result is True


### PR DESCRIPTION
## Summary

Implements advanced position sizing algorithms with portfolio-level risk controls. Replaces fixed % allocation with 4 sizing methods.

Closes #66

## Changes

### Core Implementation
- **New file: `helpers/position_sizing.py`**
  - `calculate_position_size()` - main entry point routing to 4 methods
  - `check_portfolio_heat()` - enforces max total portfolio risk
  - Private functions for each sizing method

### Position Sizing Methods

**1. Fixed (default, backward compatible)**
```python
shares = (equity * allocation_pct) / price
```

**2. Kelly Criterion (optimal growth)**
```python
kelly_f = (p * b - q) / b
shares = (equity * kelly_f * kelly_fraction) / price
```
- Requires historical win_rate, avg_win, avg_loss
- Falls back to fixed when stats unavailable
- Uses fractional Kelly (25% default) for safety

**3. Volatility Parity (inverse ATR)**
```python
shares = (equity * target_risk) / (price * atr_pct)
```
- Lower volatility → larger positions
- Higher volatility → smaller positions

**4. Risk Parity (equal $ risk)**
```python
shares = (equity * target_risk) / (price * stop_distance_pct)
```
- Each position risks the same $ amount
- Falls back to ATR-based stop if none provided

### Integration
- Replaces fixed allocation logic in `helpers/portfolio_simulations.py` (lines 228-236)
- Cash constraint still enforced after sizing
- All subsequent logic (volume filter, market impact, etc.) unchanged

### Config (SECTION 22)
```python
"position_sizing_method": "fixed",  # "fixed", "kelly", "vol_parity", "risk_parity"
"kelly_fraction": 0.25,             # Conservative fractional Kelly
"target_risk_per_trade": 0.02,     # 2% risk per trade (vol/risk parity)
"max_portfolio_heat": 0.10,        # 10% max total portfolio risk
```

## Testing

**New tests:** `tests/test_position_sizing.py` - 24 tests covering:
- All 4 sizing methods with correct formulas
- Fallback behavior (Kelly without stats, vol parity without ATR, etc.)
- Portfolio heat limit enforcement
- Edge cases (zero price, negative Kelly, missing data)

**Regression:** All 906 tests passing ✅ (882 original + 24 new)

## Files Modified
- `config.py`
- `helpers/config_validator.py`
- `helpers/portfolio_simulations.py`

## Usage Example

```python
# In config.py
CONFIG = {
    ...
    "position_sizing_method": "vol_parity",  # or "fixed", "kelly", "risk_parity"
    "target_risk_per_trade": 0.02,           # 2% risk per trade
    "max_portfolio_heat": 0.10,              # 10% total portfolio risk limit
}
```

**Vol parity example:**
- Symbol A: ATR = 2%, receives 100 shares
- Symbol B: ATR = 8%, receives 25 shares (4x less due to 4x higher vol)
- Both risk ~2% of equity if ATR move occurs

## Backward Compatibility

✅ Default `position_sizing_method="fixed"` preserves existing behavior
✅ All existing tests pass without modification
✅ New config keys optional with sensible defaults

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)