### PR TITLE
fix: strip tz-info before WFA timestamp comparisons (#80)

### DIFF
--- a/helpers/wfa.py
+++ b/helpers/wfa.py
@@ -119,6 +119,8 @@ def split_trades(
     """
     # Convert split_date string to pd.Timestamp for proper comparison
     split_ts = pd.Timestamp(split_date)
+    if split_ts.tzinfo is not None:
+        split_ts = split_ts.tz_localize(None)
 
     is_trades = []
     oos_trades = []
@@ -126,6 +128,8 @@ def split_trades(
     for t in trade_log:
         # Convert ExitDate string to pd.Timestamp
         exit_ts = pd.Timestamp(t["ExitDate"])
+        if exit_ts.tzinfo is not None:
+            exit_ts = exit_ts.tz_localize(None)
 
         if exit_ts < split_ts:
             is_trades.append(t)

--- a/helpers/wfa_rolling.py
+++ b/helpers/wfa_rolling.py
@@ -105,13 +105,19 @@ def evaluate_rolling_wfa(
     for oos_start, oos_end in fold_dates:
         # Convert fold boundary strings to pd.Timestamp for datetime handling
         oos_start_ts = pd.Timestamp(oos_start)
+        if oos_start_ts.tzinfo is not None:
+            oos_start_ts = oos_start_ts.tz_localize(None)
         oos_end_ts = pd.Timestamp(oos_end)
+        if oos_end_ts.tzinfo is not None:
+            oos_end_ts = oos_end_ts.tz_localize(None)
 
         # Convert ExitDate strings to pd.Timestamp for comparison
         is_trades = []
         oos_trades = []
         for t in trade_log:
             exit_ts = pd.Timestamp(t["ExitDate"])
+            if exit_ts.tzinfo is not None:
+                exit_ts = exit_ts.tz_localize(None)
             if exit_ts < oos_start_ts:
                 is_trades.append(t)
             elif oos_start_ts <= exit_ts < oos_end_ts:


### PR DESCRIPTION
## Summary

- Fixes #80 — `TypeError: Cannot compare tz-naive and tz-aware timestamps` crash in `split_trades` when using Yahoo Finance as the data provider with WFA enabled.
- Same guard applied to `helpers/wfa_rolling.py` fold boundary comparisons.

## Root Cause

Phase 4 of #55 normalized datetime indexes to UTC-aware for daily data (Yahoo Finance). `wfa_split_date` inherits this tzinfo when derived from `spy_df.index`. Trade log `ExitDate` strings parse to tz-naive `pd.Timestamp`, causing pandas to raise `TypeError` on `<` comparison.

## Changes

| File | Change |
|---|---|
| `helpers/wfa.py` | Strip tzinfo from `split_ts` and `exit_ts` before comparison in `split_trades()` |
| `helpers/wfa_rolling.py` | Strip tzinfo from `oos_start_ts`, `oos_end_ts`, and `exit_ts` before fold boundary comparisons |

## Test plan

- [ ] Run `python main.py` with `data_provider = "yahoo"` and `wfa_split_ratio = 0.80` — no `TypeError`
- [ ] Existing `tests/test_wfa.py` (39 tests) pass
- [ ] Existing `tests/test_wfa_rolling.py` (11 tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)