### PR TITLE
fix: only fetch QQQ when benchmark_symbol = QQQ (closes #83)

### DIFF
--- a/main.py
+++ b/main.py
@@ -369,8 +369,12 @@ def main():
     try:
         spy_df = data_fetcher('SPY', CONFIG["start_date"], CONFIG["end_date"], CONFIG)
         spy_buy_and_hold_return = (spy_df['Close'].iloc[-1] - spy_df['Close'].iloc[0]) / spy_df['Close'].iloc[0]
-        qqq_df = data_fetcher('QQQ', CONFIG["start_date"], CONFIG["end_date"], CONFIG)
-        qqq_buy_and_hold_return = (qqq_df['Close'].iloc[-1] - qqq_df['Close'].iloc[0]) / qqq_df['Close'].iloc[0]
+        _benchmark = CONFIG.get("benchmark_symbol", "SPY").upper()
+        if _benchmark == "QQQ":
+            qqq_df = data_fetcher('QQQ', CONFIG["start_date"], CONFIG["end_date"], CONFIG)
+            qqq_buy_and_hold_return = (qqq_df['Close'].iloc[-1] - qqq_df['Close'].iloc[0]) / qqq_df['Close'].iloc[0]
+        else:
+            qqq_buy_and_hold_return = 0.0
         vix_df = data_fetcher("I:VIX", CONFIG["start_date"], CONFIG["end_date"], CONFIG) # Simplified
         tnx_df = data_fetcher("I:TNX", CONFIG["start_date"], CONFIG["end_date"], CONFIG) # Simplified
         _spy_actual_start = spy_df.index.min().strftime("%Y-%m-%d")


### PR DESCRIPTION
## Summary

- QQQ was hardcoded to fetch unconditionally on every run, ignoring `benchmark_symbol` in config
- If the data provider couldn't supply QQQ (e.g. parquet provider without `QQQ.parquet`), the run crashed immediately with `AttributeError` on `NoneType`
- Fix: gate the QQQ fetch behind `benchmark_symbol == "QQQ"`; default `qqq_buy_and_hold_return` to `0.0` for all other benchmark settings

Closes #83

## Test plan
- [ ] Run with `benchmark_symbol = "SPY"` — QQQ should not be fetched, no crash
- [ ] Run with `benchmark_symbol = "QQQ"` — QQQ fetched as before
- [ ] Full test suite: 882 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)