### PR TITLE
feat: print copy-paste report command at end of run (closes #86)

### DIFF
--- a/main.py
+++ b/main.py
@@ -613,6 +613,17 @@ def main():
 
     mins, secs = divmod(duration_seconds, 60)
     logger.info(f"All portfolio simulations complete in {int(mins)}m {secs:.2f}s.")
+    _print_report_hint(run_folder_name)
+
+
+def _print_report_hint(run_folder_name: str) -> None:
+    """Log a copy-paste ready report command at the end of a run."""
+    run_path = os.path.join("output", "runs", run_folder_name)
+    cmd = f"python report.py --all {run_path}"
+    bar = "━" * len(cmd)
+    logger.info(bar)
+    logger.info(f"  Run report:  {cmd}")
+    logger.info(bar)
 
 if __name__ == "__main__":
     main()

--- a/tests/test_report_command_hint.py
+++ b/tests/test_report_command_hint.py
@@ -1,0 +1,80 @@
+"""
+tests/test_report_command_hint.py
+
+Tests for the copy-paste report command hint printed at the end of every run.
+
+Covers:
+    - Correct command string format
+    - Correct run path embedded in command
+    - Visual separator lines present and consistent
+    - Works for typical run IDs (timestamped and named)
+    - logger.info called the expected number of times
+"""
+
+import os
+from unittest.mock import call, patch
+
+import pytest
+
+from main import _print_report_hint
+
+
+class TestPrintReportHint:
+
+    def _captured_calls(self, run_folder_name: str) -> list[str]:
+        """Run _print_report_hint and return the list of strings passed to logger.info."""
+        with patch("main.logger") as mock_logger:
+            _print_report_hint(run_folder_name)
+            return [c.args[0] for c in mock_logger.info.call_args_list]
+
+    def test_logs_three_lines(self):
+        lines = self._captured_calls("2026-04-05_21-01-37")
+        assert len(lines) == 3
+
+    def test_command_contains_report_py(self):
+        lines = self._captured_calls("2026-04-05_21-01-37")
+        assert any("report.py" in l for l in lines)
+
+    def test_command_contains_all_flag(self):
+        lines = self._captured_calls("2026-04-05_21-01-37")
+        assert any("--all" in l for l in lines)
+
+    def test_command_contains_run_folder_name(self):
+        run_id = "2026-04-05_21-01-37"
+        lines = self._captured_calls(run_id)
+        assert any(run_id in l for l in lines)
+
+    def test_command_contains_correct_path(self):
+        run_id = "2026-04-05_21-01-37"
+        expected_path = os.path.join("output", "runs", run_id)
+        lines = self._captured_calls(run_id)
+        assert any(expected_path in l for l in lines)
+
+    def test_command_is_copy_pasteable(self):
+        """Command line must start with 'python report.py --all'."""
+        run_id = "myrun_2026-04-05_21-01-37"
+        lines = self._captured_calls(run_id)
+        cmd_line = next(l for l in lines if "report.py" in l)
+        assert "python report.py --all" in cmd_line
+
+    def test_separator_lines_match_command_length(self):
+        """Both separator bars must be the same length as the command string."""
+        run_id = "2026-04-05_21-01-37"
+        lines = self._captured_calls(run_id)
+        bar, cmd_line, bar2 = lines
+        # The command is indented in the middle line; bar width = raw cmd length
+        raw_cmd = f"python report.py --all {os.path.join('output', 'runs', run_id)}"
+        assert len(bar) == len(raw_cmd)
+        assert bar == bar2
+
+    def test_named_run_id_included(self):
+        """Named runs (with --name prefix) must appear correctly."""
+        run_id = "mybacktest_2026-04-05_21-01-37"
+        lines = self._captured_calls(run_id)
+        assert any(run_id in l for l in lines)
+
+    def test_separator_uses_heavy_bar_character(self):
+        """Separator must use ━ (U+2501 BOX DRAWINGS HEAVY HORIZONTAL)."""
+        lines = self._captured_calls("2026-04-05_21-01-37")
+        bar = lines[0]
+        assert all(c == "━" for c in bar)


### PR DESCRIPTION
## Summary

- Prints a ready-to-run `report.py` command at the end of every successful backtest
- Intern/user can copy directly from terminal output into a new terminal — no manual path construction needed

**Example output:**
```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Run report:  python report.py --all output/runs/2026-04-05_21-01-37
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

## Changes
- `main.py`: extracted `_print_report_hint(run_folder_name)` helper, called as final step of `main()`
- `tests/test_report_command_hint.py`: 9 tests — command format, `--all` flag, run path, separator length/character, named runs

## Test plan
- [x] 9 new tests, all passing
- [x] Full suite: 891 passed, 0 failed

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)