### PR TITLE
hotfix: use forward slashes in report hint path (closes #88)

### DIFF
--- a/main.py
+++ b/main.py
@@ -618,7 +618,7 @@ def main():
 
 def _print_report_hint(run_folder_name: str) -> None:
     """Log a copy-paste ready report command at the end of a run."""
-    run_path = os.path.join("output", "runs", run_folder_name)
+    run_path = f"output/runs/{run_folder_name}"
     cmd = f"python report.py --all {run_path}"
     bar = "━" * len(cmd)
     logger.info(bar)

--- a/tests/test_report_command_hint.py
+++ b/tests/test_report_command_hint.py
@@ -46,7 +46,7 @@ class TestPrintReportHint:
 
     def test_command_contains_correct_path(self):
         run_id = "2026-04-05_21-01-37"
-        expected_path = os.path.join("output", "runs", run_id)
+        expected_path = f"output/runs/{run_id}"
         lines = self._captured_calls(run_id)
         assert any(expected_path in l for l in lines)
 


### PR DESCRIPTION
## Bug

`os.path.join()` produces backslashes on Windows. When copied into Git Bash / MINGW64, the backslashes are stripped, collapsing the path:

```
# What was printed:
python report.py --all output\runs\2026-04-05_21-58-38

# What Git Bash saw:
python report.py --all outputruns2026-04-05_21-58-38
# → ERROR: analyzer_csvs/ not found under: outputruns2026-04-05_21-58-38
```

## Fix

Replace `os.path.join("output", "runs", run_folder_name)` with `f"output/runs/{run_folder_name}"`. Forward slashes work on Windows (Python, CMD, PowerShell, Git Bash all accept them), macOS, and Linux.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)