### PR TITLE
fix: omit QQQ B&H log line when benchmark is not QQQ (#90)

### DIFF
--- a/main.py
+++ b/main.py
@@ -382,7 +382,10 @@ def main():
         logger.info("-" * 60)
         logger.info(f"  Actual Data Period : {_spy_actual_start} -> {_spy_actual_end}  (via SPY)")
         logger.info("-" * 60)
-        logger.info(f"SPY B&H: {spy_buy_and_hold_return:.2%}, QQQ B&H: {qqq_buy_and_hold_return:.2%}")
+        if _benchmark == "QQQ":
+            logger.info(f"SPY B&H: {spy_buy_and_hold_return:.2%}, QQQ B&H: {qqq_buy_and_hold_return:.2%}")
+        else:
+            logger.info(f"SPY B&H: {spy_buy_and_hold_return:.2%}")
     except Exception as e:
         logger.error(f"FATAL: Could not fetch dependency data: {e}")
         return


### PR DESCRIPTION
## Summary

- The QQQ fetch was already gated on `benchmark_symbol == "QQQ"` (hotfix #84), but the log line on main.py:385 still unconditionally printed `QQQ B&H: 0.00%` when SPY was the configured benchmark
- Now the log only includes the QQQ figure when QQQ was actually fetched

**Before:**
```
SPY B&H: 1514.46%, QQQ B&H: 0.00%
```

**After (benchmark=SPY):**
```
SPY B&H: 1514.46%
```

## Test plan

- [ ] Run with `benchmark_symbol` unset (defaults to SPY) — verify only `SPY B&H:` appears
- [ ] Run with `benchmark_symbol = "QQQ"` — verify both `SPY B&H:` and `QQQ B&H:` appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)