### PR TITLE
fix: remove silent 4-ticker fallback; add comparison_tickers to config.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -71,11 +71,20 @@ CONFIG = {
     # Use a simple string for this setting. The service modules interpret it.
     "price_adjustment": "total_return", # Options: "total_return" or "none"
 
-    # --- Benchmark Symbol ---
-    # Pipe in a benchmark to compare the backtest to.
-    # Based on 'buy and hold' comparison only.
-    # Limited to one symbol.
-    "benchmark_symbol": "SPY",
+    # --- Comparison Tickers ---
+    # Controls which external symbols are fetched alongside your portfolio data.
+    # Roles:
+    #   "benchmark"  — shown as a B&H return column in the summary table
+    #   "dependency" — injected into strategies that declare dependencies=["spy"] etc.
+    #   "both"       — serves both roles
+    # Remove any entry whose data you don't have (e.g. when using parquet provider
+    # without SPY/VIX parquet files). At minimum keep one symbol with role "benchmark"
+    # or "both" so the engine can determine the actual data period.
+    "comparison_tickers": [
+        {"symbol": "SPY",   "role": "both",       "label": "SPY"},
+        {"symbol": "I:VIX", "role": "dependency", "label": "VIX"},
+        {"symbol": "I:TNX", "role": "dependency", "label": "TNX"},
+    ],
 
     # ============================================================
     # SECTION 5: FILE OUTPUT

--- a/helpers/comparison_tickers.py
+++ b/helpers/comparison_tickers.py
@@ -108,13 +108,19 @@ def parse_comparison_tickers(config: dict) -> dict[str, Any]:
     """
     comparison_tickers = config.get("comparison_tickers")
 
-    # Fallback to legacy if not set or empty
     if not comparison_tickers:
-        logger.debug(
-            "comparison_tickers not set in config — using legacy defaults "
-            "(SPY, QQQ, VIX, TNX)"
+        raise ValueError(
+            "CONFIG['comparison_tickers'] is not set. "
+            "Add it to config.py — for example:\n\n"
+            '    "comparison_tickers": [\n'
+            '        {"symbol": "SPY",   "role": "both"},\n'
+            '        {"symbol": "I:VIX", "role": "dependency"},\n'
+            '        {"symbol": "I:TNX", "role": "dependency"},\n'
+            "    ]\n\n"
+            "Set role='benchmark' to compare B&H returns, "
+            "'dependency' to make the ticker available to strategies, "
+            "or 'both' for both."
         )
-        comparison_tickers = get_legacy_comparison_tickers()
 
     # Parse and validate each ticker entry
     benchmarks = []

--- a/tests/test_comparison_tickers.py
+++ b/tests/test_comparison_tickers.py
@@ -4,7 +4,7 @@ Unit tests for helpers/comparison_tickers.py — comparison ticker config parser
 
 Tests cover:
 - Valid configs (single benchmark, multiple benchmarks, mixed roles)
-- Legacy fallback behavior
+- Missing/empty key raises ValueError (no silent fallback)
 - Duplicate symbol handling
 - Invalid role values
 - Missing required keys
@@ -192,31 +192,25 @@ class TestParseValidConfigs:
 # ---------------------------------------------------------------------------
 
 class TestParseFallbackAndEdgeCases:
-    """Test legacy fallback and edge case handling."""
+    """Test explicit error and edge case handling."""
 
-    def test_missing_key_uses_legacy(self):
-        """Missing comparison_tickers key triggers legacy fallback."""
-        config = {}  # No comparison_tickers key
-        result = parse_comparison_tickers(config)
+    def test_missing_key_raises(self):
+        """Missing comparison_tickers key raises ValueError with helpful message."""
+        config = {}
+        with pytest.raises(ValueError, match="comparison_tickers"):
+            parse_comparison_tickers(config)
 
-        # Should have legacy symbols (SPY, QQQ, VIX, TNX)
-        assert len(result["all_symbols"]) == 4
-        assert "SPY" in result["all_symbols"]
-        assert "QQQ" in result["all_symbols"]
-
-    def test_empty_list_uses_legacy(self):
-        """Empty comparison_tickers list triggers legacy fallback."""
+    def test_empty_list_raises(self):
+        """Empty comparison_tickers list raises ValueError."""
         config = {"comparison_tickers": []}
-        result = parse_comparison_tickers(config)
+        with pytest.raises(ValueError, match="comparison_tickers"):
+            parse_comparison_tickers(config)
 
-        assert len(result["all_symbols"]) == 4  # Legacy defaults
-
-    def test_none_value_uses_legacy(self):
-        """comparison_tickers=None triggers legacy fallback."""
+    def test_none_value_raises(self):
+        """comparison_tickers=None raises ValueError."""
         config = {"comparison_tickers": None}
-        result = parse_comparison_tickers(config)
-
-        assert len(result["all_symbols"]) == 4  # Legacy defaults
+        with pytest.raises(ValueError, match="comparison_tickers"):
+            parse_comparison_tickers(config)
 
     def test_duplicate_symbol_keeps_first(self):
         """Duplicate symbols are skipped (first occurrence kept)."""


### PR DESCRIPTION
## Summary

- Previously, omitting `comparison_tickers` from config.py silently fetched SPY, QQQ, VIX, and TNX — confusing users (especially parquet provider users) who never configured them
- `parse_comparison_tickers()` now raises `ValueError` with a clear message pointing to config.py when the key is missing or empty
- `config.py` now has an explicit `comparison_tickers` block so it's always visible and user-controlled (defaults: SPY as both benchmark+dependency, VIX and TNX as dependencies)
- QQQ removed from the default — it was never needed unless explicitly wanted as a benchmark comparison
- 3 test assertions updated from "uses legacy" → "raises ValueError"

## Test plan

- [ ] Remove `comparison_tickers` from config.py and verify run fails with clear error message
- [ ] Run with default config — verify only SPY, VIX, TNX are fetched (not QQQ)
- [ ] All 956 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)