### PR TITLE
fix: allow empty comparison_tickers; derive period from config dates (#92)

### DIFF
--- a/config.py
+++ b/config.py
@@ -77,9 +77,9 @@ CONFIG = {
     #   "benchmark"  — shown as a B&H return column in the summary table
     #   "dependency" — injected into strategies that declare dependencies=["spy"] etc.
     #   "both"       — serves both roles
-    # Remove any entry whose data you don't have (e.g. when using parquet provider
-    # without SPY/VIX parquet files). At minimum keep one symbol with role "benchmark"
-    # or "both" so the engine can determine the actual data period.
+    # Set to [] to run with no comparison tickers (e.g. pure parquet runs where you
+    # have no SPY/VIX files). The engine falls back to config start_date/end_date for
+    # the period. Strategies declaring dependencies=["spy"] etc. will be skipped.
     "comparison_tickers": [
         {"symbol": "SPY",   "role": "both",       "label": "SPY"},
         {"symbol": "I:VIX", "role": "dependency", "label": "VIX"},

--- a/helpers/comparison_tickers.py
+++ b/helpers/comparison_tickers.py
@@ -108,7 +108,7 @@ def parse_comparison_tickers(config: dict) -> dict[str, Any]:
     """
     comparison_tickers = config.get("comparison_tickers")
 
-    if not comparison_tickers:
+    if comparison_tickers is None:
         raise ValueError(
             "CONFIG['comparison_tickers'] is not set. "
             "Add it to config.py — for example:\n\n"
@@ -119,8 +119,13 @@ def parse_comparison_tickers(config: dict) -> dict[str, Any]:
             "    ]\n\n"
             "Set role='benchmark' to compare B&H returns, "
             "'dependency' to make the ticker available to strategies, "
-            "or 'both' for both."
+            "or 'both' for both. "
+            "Use [] to run with no comparison tickers."
         )
+
+    # Empty list is explicitly valid — user wants no comparison tickers
+    if not comparison_tickers:
+        return {"benchmarks": [], "dependencies": {}, "all_symbols": [], "comparison_tickers": []}
 
     # Parse and validate each ticker entry
     benchmarks = []

--- a/main.py
+++ b/main.py
@@ -390,22 +390,21 @@ def main():
             else:
                 logger.warning(f"Failed to fetch data for comparison ticker '{symbol}' (normalized: '{normalized}')")
 
-        # Extract SPY for actual period computation (fallback to first available comparison ticker)
-        spy_df = comparison_dfs.get("SPY")
-        if spy_df is None and comparison_dfs:
-            # Fallback: use the first available ticker for period info
-            first_symbol = list(comparison_dfs.keys())[0]
-            spy_df = comparison_dfs[first_symbol]
-            logger.warning(f"SPY not available — using '{first_symbol}' for Actual Data Period")
-
-        if spy_df is None:
-            raise ValueError("No comparison tickers available — cannot determine actual data period")
-
-        _spy_actual_start = spy_df.index.min().strftime("%Y-%m-%d")
-        _spy_actual_end   = spy_df.index.max().strftime("%Y-%m-%d")
-        logger.info("-" * 60)
-        logger.info(f"  Actual Data Period : {_spy_actual_start} -> {_spy_actual_end}")
-        logger.info("-" * 60)
+        # Derive actual data period from comparison ticker data if available,
+        # otherwise fall back to config dates (valid when comparison_tickers = [])
+        if comparison_dfs:
+            ref_df = comparison_dfs.get("SPY") or next(iter(comparison_dfs.values()))
+            _spy_actual_start = ref_df.index.min().strftime("%Y-%m-%d")
+            _spy_actual_end   = ref_df.index.max().strftime("%Y-%m-%d")
+            logger.info("-" * 60)
+            logger.info(f"  Actual Data Period : {_spy_actual_start} -> {_spy_actual_end}")
+            logger.info("-" * 60)
+        else:
+            _spy_actual_start = CONFIG["start_date"]
+            _spy_actual_end   = CONFIG.get("end_date") or datetime.now().strftime("%Y-%m-%d")
+            logger.info("-" * 60)
+            logger.info(f"  Data Period (config): {_spy_actual_start} -> {_spy_actual_end}  (no comparison tickers)")
+            logger.info("-" * 60)
 
         # Calculate benchmark returns
         for bm in comparison_config["benchmarks"]:

--- a/tests/test_comparison_tickers.py
+++ b/tests/test_comparison_tickers.py
@@ -200,14 +200,16 @@ class TestParseFallbackAndEdgeCases:
         with pytest.raises(ValueError, match="comparison_tickers"):
             parse_comparison_tickers(config)
 
-    def test_empty_list_raises(self):
-        """Empty comparison_tickers list raises ValueError."""
+    def test_empty_list_returns_empty_structure(self):
+        """Empty list is valid — returns empty benchmarks/dependencies/all_symbols."""
         config = {"comparison_tickers": []}
-        with pytest.raises(ValueError, match="comparison_tickers"):
-            parse_comparison_tickers(config)
+        result = parse_comparison_tickers(config)
+        assert result["benchmarks"] == []
+        assert result["dependencies"] == {}
+        assert result["all_symbols"] == []
 
     def test_none_value_raises(self):
-        """comparison_tickers=None raises ValueError."""
+        """comparison_tickers=None (key present but None) raises ValueError."""
         config = {"comparison_tickers": None}
         with pytest.raises(ValueError, match="comparison_tickers"):
             parse_comparison_tickers(config)


### PR DESCRIPTION
Closes #92.

## Summary

- `comparison_tickers: []` now works — runs the simulation with no benchmark comparison and no dependency injection
- The engine no longer needs a comparison ticker to determine the data period — it falls back to `CONFIG["start_date"]` / `CONFIG["end_date"]` when `comparison_dfs` is empty
- `None` (key present but unset) and missing key still raise `ValueError` with a helpful message
- config.py comment updated to document that `[]` is valid

## Why

SPY was never the real source of truth for the period — `config.start_date` / `config.end_date` always were. SPY was just the first thing fetched, so its date range became the anchor by accident. This blocked parquet users who don't have SPY/VIX files from running without comparison tickers.

## Test plan

- [ ] Set `"comparison_tickers": []` in config.py and run — should complete without error
- [ ] Verify output shows `Data Period (config): ...` instead of `Actual Data Period: ...`
- [ ] Verify no B&H log lines appear
- [ ] All 956 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)