### PR TITLE
fix: replace stale vix_df_global with vix_df_local in regime heatmap (#96)

### DIFF
--- a/main.py
+++ b/main.py
@@ -178,7 +178,7 @@ def run_single_simulation(args):
             from helpers.regime import build_regime_heatmap as _build_heatmap
             result["regime_heatmap"] = _build_heatmap(
                 result.get("trade_log", []),
-                vix_df_global,
+                vix_df_local,
                 result.get("initial_capital", CONFIG["initial_capital"]),
             )
 


### PR DESCRIPTION
## Bug

```
NameError: name 'vix_df_global' is not defined. Did you mean: 'vix_df_local'?
  File "main.py", line 181, in run_single_simulation
    vix_df_global,
```

## Root cause

`vix_df_global` was a leftover from the pre-PR-#60 architecture where VIX was passed as its own named global into workers. PR #60 replaced this with `comparison_dfs_global` / `dependency_map_global`. `vix_df_local` is already resolved at line 62 of `run_single_simulation` but the regime heatmap call at line 181 was never updated.

## Fix

One-line change: `vix_df_global` → `vix_df_local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)