### PR TITLE
fix: replace DataFrame or-fallback with explicit None check in period derivation

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,6 +25,20 @@ from helpers.noise import inject_price_noise
 
 logger = logging.getLogger(__name__)
 
+
+def _pick_reference_df(comparison_dfs: dict) -> pd.DataFrame:
+    """Return the reference DataFrame used to derive the actual data period.
+
+    Prefers SPY when present.  Falls back to the first available ticker.
+    Uses an explicit ``is None`` check to avoid the ``bool(DataFrame)``
+    ambiguity error that arises from the ``or`` operator on DataFrames.
+    """
+    spy = comparison_dfs.get("SPY")
+    if spy is not None:
+        return spy
+    return next(iter(comparison_dfs.values()))
+
+
 # --------------------------------------------------------------------
 # --- WORKER INITIALIZER FOR MULTIPROCESSING ---
 # --------------------------------------------------------------------
@@ -393,7 +407,7 @@ def main():
         # Derive actual data period from comparison ticker data if available,
         # otherwise fall back to config dates (valid when comparison_tickers = [])
         if comparison_dfs:
-            spy_df = comparison_dfs.get("SPY") or next(iter(comparison_dfs.values()))
+            spy_df = _pick_reference_df(comparison_dfs)
             _spy_actual_start = spy_df.index.min().strftime("%Y-%m-%d")
             _spy_actual_end   = spy_df.index.max().strftime("%Y-%m-%d")
             logger.info("-" * 60)

--- a/tests/test_period_derivation.py
+++ b/tests/test_period_derivation.py
@@ -1,0 +1,95 @@
+# tests/test_period_derivation.py
+"""
+TDD tests for main._pick_reference_df() — the helper that selects a reference
+DataFrame from comparison_dfs to derive the Actual Data Period.
+
+Regression for bug: "The truth value of a DataFrame is ambiguous"
+
+Root cause: the original inline expression
+    spy_df = comparison_dfs.get("SPY") or next(iter(comparison_dfs.values()))
+calls bool(DataFrame) when SPY is present and non-empty, which raises:
+    ValueError: The truth value of a DataFrame is ambiguous.
+
+Fix: replace the `or` fallback with an explicit `is None` check.
+"""
+
+import os
+import sys
+
+import pandas as pd
+import pytest
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from main import _pick_reference_df
+
+
+def _make_df(start="2020-01-01", periods=5):
+    """Small helper — returns a minimal DataFrame with a DatetimeIndex."""
+    return pd.DataFrame(
+        {"Close": range(periods)},
+        index=pd.date_range(start, periods=periods),
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestPickReferenceDf
+# ---------------------------------------------------------------------------
+
+
+class TestPickReferenceDf:
+    """Tests for main._pick_reference_df(comparison_dfs)."""
+
+    def test_returns_spy_when_present(self):
+        """When SPY is in comparison_dfs, the SPY DataFrame is returned — not first."""
+        spy_df = _make_df("2020-01-01")
+        qqq_df = _make_df("2019-01-01")  # Earlier start — should NOT be picked
+        comparison_dfs = {"QQQ": qqq_df, "SPY": spy_df}
+
+        result = _pick_reference_df(comparison_dfs)
+
+        assert result is spy_df, "Expected SPY to be chosen as reference"
+
+    def test_does_not_raise_with_valid_spy_df(self):
+        """Must NOT raise ValueError ('truth value of a DataFrame is ambiguous')."""
+        spy_df = _make_df()
+        comparison_dfs = {"SPY": spy_df}
+
+        # This is the regression assertion — buggy code raises ValueError here
+        try:
+            result = _pick_reference_df(comparison_dfs)
+        except ValueError as exc:
+            pytest.fail(f"_pick_reference_df raised ValueError: {exc}")
+
+        assert result is spy_df
+
+    def test_falls_back_to_first_df_when_no_spy(self):
+        """When SPY is absent, the first available DataFrame is returned."""
+        qqq_df = _make_df("2019-01-01")
+        comparison_dfs = {"QQQ": qqq_df}
+
+        result = _pick_reference_df(comparison_dfs)
+
+        assert result is qqq_df
+
+    def test_falls_back_to_first_df_multiple_non_spy(self):
+        """When multiple non-SPY tickers are present, the first is returned."""
+        qqq_df = _make_df("2019-01-01")
+        xlf_df = _make_df("2018-01-01")
+        comparison_dfs = {"QQQ": qqq_df, "XLF": xlf_df}
+
+        result = _pick_reference_df(comparison_dfs)
+
+        # First value in insertion order
+        assert result is qqq_df
+
+    def test_single_non_spy_ticker(self):
+        """Single non-SPY ticker — returns that ticker's DataFrame."""
+        vix_df = _make_df()
+        comparison_dfs = {"I:VIX": vix_df}
+
+        result = _pick_reference_df(comparison_dfs)
+
+        assert result is vix_df


### PR DESCRIPTION
## Summary

- `comparison_dfs.get("SPY") or next(iter(...))` calls `bool(DataFrame)` when SPY is present and non-empty, raising `ValueError: The truth value of a DataFrame is ambiguous`
- Extracted `_pick_reference_df(comparison_dfs)` helper using an explicit `is None` guard instead of the `or` short-circuit
- Affects all data providers (polygon, yahoo, norgate, parquet) whenever SPY fetches successfully — not parquet-specific

## Root cause

```python
# Before — crashes when SPY DataFrame is present
spy_df = comparison_dfs.get("SPY") or next(iter(comparison_dfs.values()))

# After — explicit None check avoids bool(DataFrame)
spy_df = _pick_reference_df(comparison_dfs)
```

## Test plan

- [ ] 5 new regression tests in `tests/test_period_derivation.py` (all pass)
- [ ] Full suite: 1022 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)