### PR TITLE
feat: fully-featured CLI config override system with --help-config (#117)

### DIFF
--- a/helpers/cli_config.py
+++ b/helpers/cli_config.py
@@ -1,0 +1,708 @@
+"""helpers/cli_config.py — CLI config override system for july-backtester.
+
+Public API:
+  build_parser()                      -> argparse.ArgumentParser
+  apply_overrides(config_dict, args)  -> dict  (mutates + returns)
+  parse_stop_token(token)             -> dict
+  cast_value(s)                       -> int | float | bool | str
+  print_help_config(config_dict, category)
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Stop token parser
+# ---------------------------------------------------------------------------
+
+def parse_stop_token(token: str) -> dict:
+    """Parse a stop-loss shorthand token into a config dict.
+
+    Supported formats:
+      none           -> {"type": "none"}
+      pct:0.05       -> {"type": "percentage", "value": 0.05}
+      atr:14:3.0     -> {"type": "atr", "period": 14, "multiplier": 3.0}
+    """
+    t = token.strip().lower()
+    if t == "none":
+        return {"type": "none"}
+    if t.startswith("pct:"):
+        parts = t.split(":")
+        if len(parts) != 2:
+            raise ValueError(
+                f"Invalid pct stop token: {token!r}. Expected pct:<value>, e.g. pct:0.05"
+            )
+        return {"type": "percentage", "value": float(parts[1])}
+    if t.startswith("atr:"):
+        parts = t.split(":")
+        if len(parts) != 3:
+            raise ValueError(
+                f"Invalid atr stop token: {token!r}. "
+                "Expected atr:<period>:<multiplier>, e.g. atr:14:3.0"
+            )
+        return {"type": "atr", "period": int(parts[1]), "multiplier": float(parts[2])}
+    raise ValueError(
+        f"Unknown stop token: {token!r}. "
+        "Use: none | pct:<value> | atr:<period>:<multiplier>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Value caster for --set
+# ---------------------------------------------------------------------------
+
+def cast_value(s: str) -> Any:
+    """Auto-cast a string to int, float, bool, or str (in that order)."""
+    if s.lower() == "true":
+        return True
+    if s.lower() == "false":
+        return False
+    try:
+        return int(s)
+    except ValueError:
+        pass
+    try:
+        return float(s)
+    except ValueError:
+        pass
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Parser builder
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return the full ArgumentParser for main.py."""
+    parser = argparse.ArgumentParser(
+        description="Portfolio Backtester",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Run 'python main.py --help-config' for a guided tour of all settings.\n"
+            "Run 'python main.py --help-config <category>' for a specific section.\n"
+            "Categories: data, period, portfolio, strategies, costs, stop, "
+            "filtering, mc, wfa, output\n"
+        ),
+    )
+
+    # ---- Existing flags (unchanged behaviour) ----
+    parser.add_argument(
+        "--name", type=str,
+        help="Optional prefix for the report folder name.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Validate config and print summary without fetching data or running simulations.",
+    )
+    parser.add_argument(
+        "--verbose", action="store_true",
+        help="Show all columns in the summary table (default: compact view).",
+    )
+    parser.add_argument("--init", action="store_true", help=argparse.SUPPRESS)
+
+    # ---- Guided help ----
+    parser.add_argument(
+        "--help-config", nargs="?", const="all", metavar="CATEGORY",
+        help=(
+            "Print the config reference guide. Optionally filter by category: "
+            "data, period, portfolio, strategies, costs, stop, filtering, mc, wfa, output"
+        ),
+    )
+
+    # ---- DATA ----
+    parser.add_argument(
+        "--provider", dest="data_provider", metavar="PROVIDER",
+        help="Data source: norgate | yahoo | polygon | csv | parquet",
+    )
+    parser.add_argument(
+        "--csv-dir", dest="csv_data_dir", metavar="PATH",
+        help="Folder of per-symbol CSV files (--provider csv only)",
+    )
+    parser.add_argument(
+        "--parquet-dir", dest="parquet_data_dir", metavar="PATH",
+        help="Folder of per-symbol Parquet files (--provider parquet only)",
+    )
+
+    # ---- PERIOD & CAPITAL ----
+    parser.add_argument(
+        "--start", dest="start_date", metavar="YYYY-MM-DD",
+        help="Backtest start date",
+    )
+    parser.add_argument(
+        "--end", dest="end_date", metavar="YYYY-MM-DD",
+        help="Backtest end date",
+    )
+    parser.add_argument(
+        "--capital", dest="initial_capital", type=float, metavar="USD",
+        help="Starting equity in USD",
+    )
+
+    # ---- PORTFOLIO & SYMBOLS (mutually exclusive) ----
+    sym_group = parser.add_mutually_exclusive_group()
+    sym_group.add_argument(
+        "--symbols", nargs="+", metavar="TICKER",
+        help="One or more tickers to run as a 'CLI' portfolio",
+    )
+    sym_group.add_argument(
+        "--portfolio", metavar="FILE_OR_WATCHLIST",
+        help="JSON filename or norgate:WatchlistName as a 'CLI' portfolio",
+    )
+    parser.add_argument(
+        "--min-bars", dest="min_bars_required", type=int, metavar="N",
+        help="Skip symbols with fewer than N bars",
+    )
+
+    # ---- STRATEGIES ----
+    parser.add_argument(
+        "--strategies", nargs="+", metavar="NAME",
+        help="Exact strategy names to run; use 'all' to run every registered strategy",
+    )
+
+    # ---- EXECUTION & COSTS ----
+    parser.add_argument(
+        "--allocation", dest="allocation_per_trade", type=float, metavar="FRAC",
+        help="Fraction of equity per position, e.g. 0.05",
+    )
+    parser.add_argument(
+        "--execution", dest="execution_time", metavar="TIME",
+        help="Fill time: open | close",
+    )
+    parser.add_argument(
+        "--slippage", dest="slippage_pct", type=float, metavar="FRAC",
+        help="Flat bid/ask slippage fraction, e.g. 0.0005",
+    )
+    parser.add_argument(
+        "--commission", dest="commission_per_share", type=float, metavar="USD",
+        help="Commission per share in USD, e.g. 0.002",
+    )
+    parser.add_argument(
+        "--risk-free-rate", dest="risk_free_rate", type=float, metavar="RATE",
+        help="Annual risk-free rate for Sharpe/Sortino, e.g. 0.05",
+    )
+    parser.add_argument(
+        "--htb-rate", dest="htb_rate_annual", type=float, metavar="RATE",
+        help="Annual hard-to-borrow rate for short positions, e.g. 0.02",
+    )
+    parser.add_argument(
+        "--max-pct-adv", dest="max_pct_adv", type=float, metavar="FRAC",
+        help="Max fraction of 20-day ADV per order, e.g. 0.05",
+    )
+    parser.add_argument(
+        "--volume-impact", dest="volume_impact_coeff", type=float, metavar="COEFF",
+        help="Square-root market impact coefficient. 0.0 = disabled",
+    )
+
+    # ---- STOP LOSS ----
+    parser.add_argument(
+        "--stop", dest="stop_tokens", nargs="+", metavar="TOKEN",
+        help="Stop configs: none | pct:0.05 | atr:14:3.0 (repeatable)",
+    )
+
+    # ---- FILTERING ----
+    parser.add_argument(
+        "--min-pandl", dest="min_pandl_to_show_in_summary", type=float, metavar="PCT",
+        help="Min P&L %% to show in summary. -9999 = show all",
+    )
+    parser.add_argument(
+        "--max-dd", dest="max_acceptable_drawdown", type=float, metavar="FRAC",
+        help="Max drawdown to display, e.g. 0.25. 1.0 = show all",
+    )
+    parser.add_argument(
+        "--min-mc-score", dest="mc_score_min_to_show_in_summary", type=float, metavar="SCORE",
+        help="Min MC score to display. -9999 = show all",
+    )
+    parser.add_argument(
+        "--min-vs-spy", dest="min_performance_vs_spy", type=float, metavar="PCT",
+        help="Min outperformance vs SPY. 0.0 = must beat. -9999 = show all",
+    )
+
+    # ---- MONTE CARLO ----
+    parser.add_argument(
+        "--mc-sims", dest="num_mc_simulations", type=int, metavar="N",
+        help="Number of MC simulations",
+    )
+    parser.add_argument(
+        "--min-trades-mc", dest="min_trades_for_mc", type=int, metavar="N",
+        help="Min trades required to run MC",
+    )
+    parser.add_argument(
+        "--mc-sampling", dest="mc_sampling", metavar="METHOD",
+        help="MC resampling method: iid | block",
+    )
+
+    # ---- WFA ----
+    parser.add_argument(
+        "--wfa-split", dest="wfa_split_ratio", type=float, metavar="RATIO",
+        help="WFA in-sample fraction, e.g. 0.80. 0 = disable WFA",
+    )
+    parser.add_argument(
+        "--wfa-folds", dest="wfa_folds", type=int, metavar="N",
+        help="Rolling WFA folds. 0 = disable rolling WFA",
+    )
+
+    # ---- OUTPUT & MISC ----
+    parser.add_argument(
+        "--save-trades", dest="save_individual_trades",
+        action=argparse.BooleanOptionalAction,
+        help="Save per-strategy trade CSVs (default: on)",
+    )
+    parser.add_argument(
+        "--save-filtered-only", dest="save_only_filtered_trades",
+        action=argparse.BooleanOptionalAction,
+        help="Only save trades for strategies that passed display filters",
+    )
+    parser.add_argument(
+        "--noise", dest="noise_injection_pct", type=float, metavar="FRAC",
+        help="Price noise injection fraction. 0.0 = disabled",
+    )
+    parser.add_argument(
+        "--rolling-sharpe", dest="rolling_sharpe_window", type=int, metavar="BARS",
+        help="Rolling Sharpe window in trading days. 0 = disabled",
+    )
+    parser.add_argument(
+        "--export-ml", dest="export_ml_features",
+        action=argparse.BooleanOptionalAction,
+        help="Export ML trade features to Parquet after the run",
+    )
+    parser.add_argument(
+        "--upload-s3", dest="upload_to_s3",
+        action=argparse.BooleanOptionalAction,
+        help="Upload reports to the configured S3 bucket",
+    )
+
+    # ---- ESCAPE HATCH ----
+    parser.add_argument(
+        "--set", dest="overrides", action="append", metavar="KEY=VALUE",
+        help=(
+            "Override any config key not covered by a named flag, "
+            "e.g. --set rolling_sharpe_window=252. Repeatable."
+        ),
+    )
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Apply overrides
+# ---------------------------------------------------------------------------
+
+# Keys with a direct 1-to-1 mapping between argparse dest and CONFIG key.
+_DIRECT_KEYS = [
+    "data_provider", "csv_data_dir", "parquet_data_dir",
+    "start_date", "end_date", "initial_capital",
+    "min_bars_required",
+    "allocation_per_trade", "execution_time",
+    "slippage_pct", "commission_per_share", "risk_free_rate",
+    "htb_rate_annual", "max_pct_adv", "volume_impact_coeff",
+    "min_pandl_to_show_in_summary", "max_acceptable_drawdown",
+    "mc_score_min_to_show_in_summary", "min_performance_vs_spy",
+    "num_mc_simulations", "min_trades_for_mc", "mc_sampling",
+    "save_individual_trades", "save_only_filtered_trades",
+    "noise_injection_pct", "rolling_sharpe_window",
+    "export_ml_features", "upload_to_s3",
+]
+
+
+def apply_overrides(config_dict: dict, args: argparse.Namespace) -> dict:
+    """Apply parsed CLI args to config_dict in-place. Returns config_dict."""
+
+    # 1. Direct 1:1 keys — only apply when explicitly set (not None)
+    for key in _DIRECT_KEYS:
+        val = getattr(args, key, None)
+        if val is not None:
+            config_dict[key] = val
+
+    # 2. portfolios: --symbols builds an inline list; --portfolio builds a file/watchlist ref
+    if getattr(args, "symbols", None):
+        config_dict["portfolios"] = {"CLI": list(args.symbols)}
+    elif getattr(args, "portfolio", None):
+        config_dict["portfolios"] = {"CLI": args.portfolio}
+
+    # 3. strategies: 'all' string or list of names
+    if getattr(args, "strategies", None):
+        strats = args.strategies
+        if len(strats) == 1 and strats[0].lower() == "all":
+            config_dict["strategies"] = "all"
+        else:
+            config_dict["strategies"] = list(strats)
+
+    # 4. stop_loss_configs from shorthand tokens
+    if getattr(args, "stop_tokens", None):
+        config_dict["stop_loss_configs"] = [
+            parse_stop_token(t) for t in args.stop_tokens
+        ]
+
+    # 5. wfa_split_ratio: 0.0 means disabled (None)
+    wfa_split = getattr(args, "wfa_split_ratio", None)
+    if wfa_split is not None:
+        config_dict["wfa_split_ratio"] = None if wfa_split == 0.0 else wfa_split
+
+    # 6. wfa_folds: 0 means disabled (None)
+    wfa_folds = getattr(args, "wfa_folds", None)
+    if wfa_folds is not None:
+        config_dict["wfa_folds"] = None if wfa_folds == 0 else wfa_folds
+
+    # 7. --set escape hatch
+    for item in (getattr(args, "overrides", None) or []):
+        if "=" not in item:
+            print(f"[WARNING] --set value ignored (no '='): {item!r}", file=sys.stderr)
+            continue
+        k, v = item.split("=", 1)
+        config_dict[k.strip()] = cast_value(v.strip())
+
+    return config_dict
+
+
+# ---------------------------------------------------------------------------
+# Guided help
+# ---------------------------------------------------------------------------
+
+_SECTIONS: list[tuple[str, str, list[dict]]] = [
+    ("data", "DATA", [
+        {
+            "flag": "--provider <str>",
+            "config_key": "data_provider",
+            "desc": "Which data source to use.",
+            "options": "norgate | yahoo | polygon | csv | parquet",
+            "example": "python main.py --provider yahoo",
+        },
+        {
+            "flag": "--csv-dir <path>",
+            "config_key": "csv_data_dir",
+            "desc": "Folder of per-symbol CSV files (--provider csv only).",
+            "options": None,
+            "example": "python main.py --provider csv --csv-dir ./my_data",
+        },
+        {
+            "flag": "--parquet-dir <path>",
+            "config_key": "parquet_data_dir",
+            "desc": "Folder of per-symbol Parquet files (--provider parquet only).",
+            "options": None,
+            "example": "python main.py --provider parquet --parquet-dir ./parquet_data",
+        },
+    ]),
+    ("period", "PERIOD & CAPITAL", [
+        {
+            "flag": "--start <YYYY-MM-DD>",
+            "config_key": "start_date",
+            "desc": "Backtest start date.",
+            "options": None,
+            "example": "python main.py --start 2015-01-01",
+        },
+        {
+            "flag": "--end <YYYY-MM-DD>",
+            "config_key": "end_date",
+            "desc": "Backtest end date. Defaults to today.",
+            "options": None,
+            "example": "python main.py --end 2023-12-31",
+        },
+        {
+            "flag": "--capital <float>",
+            "config_key": "initial_capital",
+            "desc": "Starting equity in USD.",
+            "options": None,
+            "example": "python main.py --capital 50000",
+        },
+    ]),
+    ("portfolio", "PORTFOLIO & SYMBOLS", [
+        {
+            "flag": "--symbols <TICKER> [<TICKER> ...]",
+            "config_key": "portfolios",
+            "desc": (
+                "One or more tickers as an inline 'CLI' portfolio.\n"
+                "      Mutually exclusive with --portfolio."
+            ),
+            "options": None,
+            "example": "python main.py --symbols AAPL MSFT NVDA",
+        },
+        {
+            "flag": "--portfolio <FILE_OR_WATCHLIST>",
+            "config_key": "portfolios",
+            "desc": (
+                "JSON file or Norgate watchlist name as a 'CLI' portfolio.\n"
+                "      Mutually exclusive with --symbols."
+            ),
+            "options": None,
+            "example": "python main.py --portfolio nasdaq_100.json",
+        },
+        {
+            "flag": "--min-bars <int>",
+            "config_key": "min_bars_required",
+            "desc": "Skip any symbol with fewer bars than this.",
+            "options": None,
+            "example": "python main.py --min-bars 500",
+        },
+    ]),
+    ("strategies", "STRATEGIES", [
+        {
+            "flag": "--strategies <NAME> [<NAME> ...]",
+            "config_key": "strategies",
+            "desc": (
+                "Exact strategy names to run (case-sensitive).\n"
+                "      Use 'all' to run every registered strategy."
+            ),
+            "options": None,
+            "example": 'python main.py --strategies "SMA Crossover (20d/50d)"',
+        },
+    ]),
+    ("costs", "EXECUTION & COSTS", [
+        {
+            "flag": "--allocation <float>",
+            "config_key": "allocation_per_trade",
+            "desc": "Fraction of total equity allocated per position (0.10 = 10%).",
+            "options": "0 < value <= 1.0",
+            "example": "python main.py --allocation 0.05",
+        },
+        {
+            "flag": "--execution <str>",
+            "config_key": "execution_time",
+            "desc": "Fill time for entries and exits.",
+            "options": "open | close",
+            "example": "python main.py --execution close",
+        },
+        {
+            "flag": "--slippage <float>",
+            "config_key": "slippage_pct",
+            "desc": "Flat bid/ask slippage fraction on every fill.",
+            "options": None,
+            "example": "python main.py --slippage 0.001",
+        },
+        {
+            "flag": "--commission <float>",
+            "config_key": "commission_per_share",
+            "desc": "Commission in USD per share.",
+            "options": None,
+            "example": "python main.py --commission 0.005",
+        },
+        {
+            "flag": "--risk-free-rate <float>",
+            "config_key": "risk_free_rate",
+            "desc": "Annual risk-free rate used in Sharpe/Sortino ratio.",
+            "options": None,
+            "example": "python main.py --risk-free-rate 0.04",
+        },
+        {
+            "flag": "--htb-rate <float>",
+            "config_key": "htb_rate_annual",
+            "desc": "Annual hard-to-borrow rate debited daily on open short positions.",
+            "options": None,
+            "example": "python main.py --htb-rate 0.10",
+        },
+        {
+            "flag": "--max-pct-adv <float>",
+            "config_key": "max_pct_adv",
+            "desc": "Max fraction of 20-day ADV a single order may consume.",
+            "options": None,
+            "example": "python main.py --max-pct-adv 0.10",
+        },
+        {
+            "flag": "--volume-impact <float>",
+            "config_key": "volume_impact_coeff",
+            "desc": "Square-root market impact coefficient. 0.0 = disabled.",
+            "options": None,
+            "example": "python main.py --volume-impact 0.1",
+        },
+    ]),
+    ("stop", "STOP LOSS", [
+        {
+            "flag": "--stop <TOKEN> [<TOKEN> ...]",
+            "config_key": "stop_loss_configs",
+            "desc": (
+                "One or more stop configs using shorthand tokens:\n"
+                "      none          no stop loss\n"
+                "      pct:0.05      5% percentage stop\n"
+                "      atr:14:3.0    ATR stop (period=14, multiplier=3.0)"
+            ),
+            "options": "none | pct:<value> | atr:<period>:<multiplier>",
+            "example": "python main.py --stop pct:0.05 pct:0.10 atr:14:3.0",
+        },
+    ]),
+    ("filtering", "FILTERING", [
+        {
+            "flag": "--min-pandl <float>",
+            "config_key": "min_pandl_to_show_in_summary",
+            "desc": "Only display strategies with P&L >= this value. -9999 = show all.",
+            "options": None,
+            "example": "python main.py --min-pandl 10.0",
+        },
+        {
+            "flag": "--max-dd <float>",
+            "config_key": "max_acceptable_drawdown",
+            "desc": "Only display strategies with max drawdown <= this fraction. 1.0 = show all.",
+            "options": None,
+            "example": "python main.py --max-dd 0.25",
+        },
+        {
+            "flag": "--min-mc-score <float>",
+            "config_key": "mc_score_min_to_show_in_summary",
+            "desc": "Only display strategies with MC score >= this value. -9999 = show all.",
+            "options": None,
+            "example": "python main.py --min-mc-score 50",
+        },
+        {
+            "flag": "--min-vs-spy <float>",
+            "config_key": "min_performance_vs_spy",
+            "desc": "Only display strategies that outperformed SPY by at least this %. -9999 = show all.",
+            "options": None,
+            "example": "python main.py --min-vs-spy 0.0",
+        },
+    ]),
+    ("mc", "MONTE CARLO", [
+        {
+            "flag": "--mc-sims <int>",
+            "config_key": "num_mc_simulations",
+            "desc": "Number of Monte Carlo simulation runs.",
+            "options": None,
+            "example": "python main.py --mc-sims 2000",
+        },
+        {
+            "flag": "--min-trades-mc <int>",
+            "config_key": "min_trades_for_mc",
+            "desc": "Minimum trades required before running MC (fewer = skip MC).",
+            "options": None,
+            "example": "python main.py --min-trades-mc 30",
+        },
+        {
+            "flag": "--mc-sampling <str>",
+            "config_key": "mc_sampling",
+            "desc": "Resampling method. iid = independent. block = preserves streaks/regimes.",
+            "options": "iid | block",
+            "example": "python main.py --mc-sampling block",
+        },
+    ]),
+    ("wfa", "WALK-FORWARD ANALYSIS", [
+        {
+            "flag": "--wfa-split <float>",
+            "config_key": "wfa_split_ratio",
+            "desc": "Fraction of data used as in-sample period. 0 = disable WFA.",
+            "options": "0 (disable) | 0.60 - 0.90",
+            "example": "python main.py --wfa-split 0.70",
+        },
+        {
+            "flag": "--wfa-folds <int>",
+            "config_key": "wfa_folds",
+            "desc": "Number of rolling WFA folds. 0 = disable rolling WFA.",
+            "options": "0 (disable) | int >= 2",
+            "example": "python main.py --wfa-folds 5",
+        },
+    ]),
+    ("output", "OUTPUT & MISC", [
+        {
+            "flag": "--save-trades / --no-save-trades",
+            "config_key": "save_individual_trades",
+            "desc": "Save per-strategy trade CSVs to the run folder.",
+            "options": None,
+            "example": "python main.py --no-save-trades",
+        },
+        {
+            "flag": "--save-filtered-only / --no-save-filtered-only",
+            "config_key": "save_only_filtered_trades",
+            "desc": "Only save trades for strategies that passed display filters.",
+            "options": None,
+            "example": "python main.py --save-filtered-only",
+        },
+        {
+            "flag": "--noise <float>",
+            "config_key": "noise_injection_pct",
+            "desc": "Inject random OHLC noise to stress-test robustness. 0.0 = disabled.",
+            "options": None,
+            "example": "python main.py --noise 0.01",
+        },
+        {
+            "flag": "--rolling-sharpe <int>",
+            "config_key": "rolling_sharpe_window",
+            "desc": "Rolling Sharpe window in trading days. 0 = disabled.",
+            "options": None,
+            "example": "python main.py --rolling-sharpe 63",
+        },
+        {
+            "flag": "--export-ml / --no-export-ml",
+            "config_key": "export_ml_features",
+            "desc": "Write consolidated ml_features.parquet after the run.",
+            "options": None,
+            "example": "python main.py --export-ml",
+        },
+        {
+            "flag": "--upload-s3 / --no-upload-s3",
+            "config_key": "upload_to_s3",
+            "desc": "Upload report files to the configured S3 bucket.",
+            "options": None,
+            "example": "python main.py --upload-s3",
+        },
+        {
+            "flag": "--set <KEY>=<VALUE>",
+            "config_key": "(any)",
+            "desc": (
+                "Override any config key not covered by a named flag.\n"
+                "      Value is auto-cast: int, float, true/false, or string.\n"
+                "      Repeatable."
+            ),
+            "options": None,
+            "example": "python main.py --set rolling_sharpe_window=252 --set htb_rate_annual=0.15",
+        },
+    ]),
+]
+
+VALID_CATEGORIES: list[str] = [s[0] for s in _SECTIONS]
+
+
+def print_help_config(config_dict: dict, category: str | None = None) -> None:
+    """Print the guided config reference to stdout."""
+    W = 66
+
+    if category is not None and category.lower() not in ("all", ""):
+        cat = category.lower()
+        if cat not in VALID_CATEGORIES:
+            print(f"\nUnknown category: {cat!r}")
+            print(f"Valid categories: {', '.join(VALID_CATEGORIES)}\n")
+            return
+        sections = [s for s in _SECTIONS if s[0] == cat]
+    else:
+        sections = _SECTIONS
+
+    print()
+    print("+" + "=" * W + "+")
+    print("|" + "  july-backtester  --  Config Reference  ".center(W) + "|")
+    print("+" + "=" * W + "+")
+
+    for _key, title, entries in sections:
+        print()
+        dash_count = max(W - len(title) - 4, 4)
+        print(f"  {title}  " + "-" * dash_count)
+
+        for entry in entries:
+            print()
+            print(f"  {entry['flag']}")
+            for line in entry["desc"].splitlines():
+                print(f"      {line}")
+            # Current live value from config
+            ckey = entry["config_key"]
+            if ckey != "(any)" and ckey in config_dict:
+                raw = config_dict[ckey]
+                if ckey == "portfolios":
+                    display = "(see config.py)"
+                elif ckey == "initial_capital":
+                    display = f"{raw:,.0f}"
+                elif isinstance(raw, float) and raw == int(raw):
+                    display = str(int(raw))
+                else:
+                    display = str(raw)
+                print(f"      Current : {display}")
+            if entry.get("options"):
+                print(f"      Options : {entry['options']}")
+            print(f"      Example : {entry['example']}")
+
+    print()
+    print("  Quick-start examples:")
+    print("    python main.py --provider yahoo --symbols AAPL --start 2020-01-01 --capital 25000")
+    print("    python main.py --portfolio nasdaq_100.json --min-vs-spy 0.0")
+    print("    python main.py --stop pct:0.05 atr:14:3.0 --mc-sims 2000 --min-pandl 5.0")
+    print("    python main.py --set rolling_sharpe_window=252 --set htb_rate_annual=0.15")
+    print()
+    if category is None or category.lower() in ("all", ""):
+        print(f"  Filter by category: python main.py --help-config <category>")
+        print(f"  Valid categories  : {', '.join(VALID_CATEGORIES)}")
+    print()

--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ import logging
 import os
 import sys
 import time
-import argparse
 import numpy as np
 import pandas as pd
 from config import CONFIG
@@ -204,18 +203,25 @@ def run_single_simulation(args):
         return None
 
 def main():
-    # --- INIT WIZARD ---
-    import argparse as _argparse
-    _parser = _argparse.ArgumentParser(add_help=False)
-    _parser.add_argument("--init", action="store_true")
-    _parser.add_argument("--dry-run", action="store_true")
-    _parser.add_argument("--all", action="store_true")
-    _known, _ = _parser.parse_known_args()
-    if _known.init:
+    # --- ARGUMENT PARSING (full parser, applied before any CONFIG reads) ---
+    from helpers.cli_config import build_parser, apply_overrides, print_help_config
+    parser = build_parser()
+    args = parser.parse_args()
+
+    # Init wizard (early exit, no CONFIG reads needed)
+    if args.init:
         from helpers.init_wizard import run_init_wizard
         run_init_wizard()
         return
-    # --- END INIT WIZARD ---
+
+    # Guided help (early exit; reads CONFIG for current-value display)
+    if args.help_config is not None:
+        print_help_config(CONFIG, args.help_config)
+        return
+
+    # Apply all CLI overrides to CONFIG before any downstream code reads it
+    apply_overrides(CONFIG, args)
+    # --- END ARGUMENT PARSING ---
 
     # --- S1: API KEY CHECK ---
     import os
@@ -264,12 +270,7 @@ def main():
         sys.exit(1)
     # --- END S2 ---
 
-    # --- ARGUMENT PARSING & FOLDER SETUP (No changes) ---
-    parser = argparse.ArgumentParser(description="Portfolio Backtester")
-    parser.add_argument("--name", type=str, help="An optional name for the backtest run, used as a prefix for the report folder.")
-    parser.add_argument("--dry-run", action="store_true", help="Validate config and print run summary without fetching data or running simulations.")
-    parser.add_argument("--verbose", action="store_true", help="Show all table columns in the summary (default: compact 7-column view).")
-    args = parser.parse_args()
+    # --- FOLDER SETUP ---
     CONFIG["verbose_output"] = args.verbose
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     run_folder_name = f"{args.name}_{timestamp}" if args.name else timestamp

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,478 @@
+"""tests/test_cli_config.py — unit tests for helpers/cli_config.py
+
+No subprocess, no file I/O, no network. All tests operate on the module
+functions directly so they run fast and deterministically.
+"""
+from __future__ import annotations
+
+import io
+import sys
+from contextlib import redirect_stdout
+
+import pytest
+
+from helpers.cli_config import (
+    VALID_CATEGORIES,
+    apply_overrides,
+    build_parser,
+    cast_value,
+    parse_stop_token,
+    print_help_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse(argv: list[str]):
+    """Parse a list of CLI tokens using build_parser()."""
+    return build_parser().parse_args(argv)
+
+
+def _cfg(**overrides) -> dict:
+    """Minimal config dict for apply_overrides tests."""
+    base = {
+        "data_provider": "norgate",
+        "csv_data_dir": "csv_data",
+        "parquet_data_dir": "parquet_data",
+        "start_date": "2004-01-01",
+        "end_date": "2026-01-01",
+        "initial_capital": 100_000.0,
+        "portfolios": {"Default": ["AAPL"]},
+        "strategies": "all",
+        "allocation_per_trade": 0.10,
+        "execution_time": "open",
+        "slippage_pct": 0.0005,
+        "commission_per_share": 0.002,
+        "risk_free_rate": 0.05,
+        "htb_rate_annual": 0.02,
+        "max_pct_adv": 0.05,
+        "volume_impact_coeff": 0.0,
+        "stop_loss_configs": [{"type": "none"}],
+        "min_pandl_to_show_in_summary": -9999,
+        "max_acceptable_drawdown": 1.0,
+        "mc_score_min_to_show_in_summary": -9999,
+        "min_performance_vs_spy": -9999,
+        "num_mc_simulations": 1000,
+        "min_trades_for_mc": 50,
+        "mc_sampling": "iid",
+        "wfa_split_ratio": 0.80,
+        "wfa_folds": None,
+        "save_individual_trades": True,
+        "save_only_filtered_trades": False,
+        "noise_injection_pct": 0.0,
+        "rolling_sharpe_window": 126,
+        "export_ml_features": False,
+        "upload_to_s3": False,
+        "min_bars_required": 250,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# TestParseStopToken
+# ---------------------------------------------------------------------------
+
+class TestParseStopToken:
+    def test_none(self):
+        assert parse_stop_token("none") == {"type": "none"}
+
+    def test_pct(self):
+        assert parse_stop_token("pct:0.05") == {"type": "percentage", "value": 0.05}
+
+    def test_atr(self):
+        result = parse_stop_token("atr:14:3.0")
+        assert result == {"type": "atr", "period": 14, "multiplier": 3.0}
+
+    def test_invalid_token_raises(self):
+        with pytest.raises(ValueError, match="Unknown stop token"):
+            parse_stop_token("fixed:100")
+
+    def test_case_insensitive(self):
+        assert parse_stop_token("NONE") == {"type": "none"}
+        assert parse_stop_token("PCT:0.10") == {"type": "percentage", "value": 0.10}
+        assert parse_stop_token("ATR:20:2.5") == {"type": "atr", "period": 20, "multiplier": 2.5}
+
+    def test_pct_missing_value_raises(self):
+        with pytest.raises(ValueError):
+            parse_stop_token("pct:")
+
+    def test_atr_missing_parts_raises(self):
+        with pytest.raises(ValueError):
+            parse_stop_token("atr:14")
+
+
+# ---------------------------------------------------------------------------
+# TestCastValue
+# ---------------------------------------------------------------------------
+
+class TestCastValue:
+    def test_int(self):
+        assert cast_value("42") == 42
+        assert isinstance(cast_value("42"), int)
+
+    def test_float(self):
+        result = cast_value("3.14")
+        assert abs(result - 3.14) < 1e-9
+        assert isinstance(result, float)
+
+    def test_true(self):
+        assert cast_value("true") is True
+        assert cast_value("True") is True
+        assert cast_value("TRUE") is True
+
+    def test_false(self):
+        assert cast_value("false") is False
+        assert cast_value("False") is False
+
+    def test_string_passthrough(self):
+        assert cast_value("norgate") == "norgate"
+        assert cast_value("block") == "block"
+
+
+# ---------------------------------------------------------------------------
+# TestApplyOverrides
+# ---------------------------------------------------------------------------
+
+class TestApplyOverrides:
+    def test_provider(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--provider", "yahoo"]))
+        assert cfg["data_provider"] == "yahoo"
+
+    def test_start_date(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--start", "2018-01-01"]))
+        assert cfg["start_date"] == "2018-01-01"
+
+    def test_capital(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--capital", "75000"]))
+        assert cfg["initial_capital"] == 75_000.0
+
+    def test_symbols_builds_cli_portfolio(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--symbols", "AAPL", "MSFT"]))
+        assert cfg["portfolios"] == {"CLI": ["AAPL", "MSFT"]}
+
+    def test_portfolio_file_builds_cli_portfolio(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--portfolio", "nasdaq_100.json"]))
+        assert cfg["portfolios"] == {"CLI": "nasdaq_100.json"}
+
+    def test_symbols_and_portfolio_are_mutually_exclusive(self):
+        with pytest.raises(SystemExit):
+            _parse(["--symbols", "AAPL", "--portfolio", "nasdaq_100.json"])
+
+    def test_strategies_list(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--strategies", "SMA Crossover (20d/50d)"]))
+        assert cfg["strategies"] == ["SMA Crossover (20d/50d)"]
+
+    def test_strategies_all(self):
+        cfg = _cfg(strategies=["SMA Crossover (20d/50d)"])
+        apply_overrides(cfg, _parse(["--strategies", "all"]))
+        assert cfg["strategies"] == "all"
+
+    def test_allocation(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--allocation", "0.05"]))
+        assert cfg["allocation_per_trade"] == pytest.approx(0.05)
+
+    def test_stop_single(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--stop", "none"]))
+        assert cfg["stop_loss_configs"] == [{"type": "none"}]
+
+    def test_stop_multiple(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--stop", "none", "pct:0.05"]))
+        assert cfg["stop_loss_configs"] == [
+            {"type": "none"},
+            {"type": "percentage", "value": 0.05},
+        ]
+
+    def test_stop_atr(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--stop", "atr:14:3.0"]))
+        assert cfg["stop_loss_configs"] == [{"type": "atr", "period": 14, "multiplier": 3.0}]
+
+    def test_min_pandl(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--min-pandl", "10.0"]))
+        assert cfg["min_pandl_to_show_in_summary"] == pytest.approx(10.0)
+
+    def test_max_dd(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--max-dd", "0.30"]))
+        assert cfg["max_acceptable_drawdown"] == pytest.approx(0.30)
+
+    def test_mc_sims(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--mc-sims", "500"]))
+        assert cfg["num_mc_simulations"] == 500
+
+    def test_wfa_split(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--wfa-split", "0.70"]))
+        assert cfg["wfa_split_ratio"] == pytest.approx(0.70)
+
+    def test_wfa_split_zero_disables_wfa(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--wfa-split", "0"]))
+        assert cfg["wfa_split_ratio"] is None
+
+    def test_wfa_folds_zero_disables_rolling(self):
+        cfg = _cfg(wfa_folds=5)
+        apply_overrides(cfg, _parse(["--wfa-folds", "0"]))
+        assert cfg["wfa_folds"] is None
+
+    def test_no_save_trades(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--no-save-trades"]))
+        assert cfg["save_individual_trades"] is False
+
+    def test_save_trades_on(self):
+        cfg = _cfg(save_individual_trades=False)
+        apply_overrides(cfg, _parse(["--save-trades"]))
+        assert cfg["save_individual_trades"] is True
+
+    def test_export_ml(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--export-ml"]))
+        assert cfg["export_ml_features"] is True
+
+    def test_set_escape_hatch_float(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--set", "noise_injection_pct=0.01"]))
+        assert cfg["noise_injection_pct"] == pytest.approx(0.01)
+
+    def test_set_escape_hatch_int(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--set", "wfa_folds=5"]))
+        assert cfg["wfa_folds"] == 5
+
+    def test_set_escape_hatch_bool(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--set", "export_ml_features=true"]))
+        assert cfg["export_ml_features"] is True
+
+    def test_set_escape_hatch_string(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--set", "mc_sampling=block"]))
+        assert cfg["mc_sampling"] == "block"
+
+    def test_set_escape_hatch_repeatable(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--set", "mc_sampling=block", "--set", "min_trades_for_mc=30"]))
+        assert cfg["mc_sampling"] == "block"
+        assert cfg["min_trades_for_mc"] == 30
+
+    def test_no_override_when_flag_not_given(self):
+        """Flags not passed must not overwrite existing config values."""
+        cfg = _cfg(start_date="2010-01-01")
+        apply_overrides(cfg, _parse(["--capital", "50000"]))
+        assert cfg["start_date"] == "2010-01-01"  # unchanged
+
+    def test_slippage(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--slippage", "0.001"]))
+        assert cfg["slippage_pct"] == pytest.approx(0.001)
+
+    def test_mc_sampling(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--mc-sampling", "block"]))
+        assert cfg["mc_sampling"] == "block"
+
+    def test_risk_free_rate(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--risk-free-rate", "0.04"]))
+        assert cfg["risk_free_rate"] == pytest.approx(0.04)
+
+    def test_min_bars(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--min-bars", "500"]))
+        assert cfg["min_bars_required"] == 500
+
+    def test_noise(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--noise", "0.01"]))
+        assert cfg["noise_injection_pct"] == pytest.approx(0.01)
+
+    def test_rolling_sharpe(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--rolling-sharpe", "63"]))
+        assert cfg["rolling_sharpe_window"] == 63
+
+    def test_upload_s3(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--upload-s3"]))
+        assert cfg["upload_to_s3"] is True
+
+    def test_commission(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--commission", "0.005"]))
+        assert cfg["commission_per_share"] == pytest.approx(0.005)
+
+    def test_htb_rate(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--htb-rate", "0.10"]))
+        assert cfg["htb_rate_annual"] == pytest.approx(0.10)
+
+    def test_volume_impact(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--volume-impact", "0.1"]))
+        assert cfg["volume_impact_coeff"] == pytest.approx(0.1)
+
+    def test_min_mc_score(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--min-mc-score", "50"]))
+        assert cfg["mc_score_min_to_show_in_summary"] == pytest.approx(50.0)
+
+    def test_min_vs_spy(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--min-vs-spy", "0.0"]))
+        assert cfg["min_performance_vs_spy"] == pytest.approx(0.0)
+
+    def test_execution_time(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--execution", "close"]))
+        assert cfg["execution_time"] == "close"
+
+    def test_provider_parquet_and_dir(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--provider", "parquet", "--parquet-dir", "./my_data"]))
+        assert cfg["data_provider"] == "parquet"
+        assert cfg["parquet_data_dir"] == "./my_data"
+
+    def test_wfa_folds_set(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--wfa-folds", "5"]))
+        assert cfg["wfa_folds"] == 5
+
+    def test_save_filtered_only(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--save-filtered-only"]))
+        assert cfg["save_only_filtered_trades"] is True
+
+    def test_min_trades_mc(self):
+        cfg = _cfg()
+        apply_overrides(cfg, _parse(["--min-trades-mc", "30"]))
+        assert cfg["min_trades_for_mc"] == 30
+
+
+# ---------------------------------------------------------------------------
+# TestBuildParser
+# ---------------------------------------------------------------------------
+
+class TestBuildParser:
+    def test_returns_argument_parser(self):
+        import argparse
+        parser = build_parser()
+        assert isinstance(parser, argparse.ArgumentParser)
+
+    def test_help_config_flag_exists(self):
+        parser = build_parser()
+        # --help-config should be parseable with and without a value
+        args = parser.parse_args(["--help-config"])
+        assert args.help_config == "all"
+        args2 = parser.parse_args(["--help-config", "mc"])
+        assert args2.help_config == "mc"
+
+    def test_existing_flags_still_work(self):
+        args = _parse(["--name", "myrun", "--dry-run", "--verbose"])
+        assert args.name == "myrun"
+        assert args.dry_run is True
+        assert args.verbose is True
+
+    def test_all_expected_dests_present(self):
+        args = _parse([])
+        expected_dests = [
+            "data_provider", "csv_data_dir", "parquet_data_dir",
+            "start_date", "end_date", "initial_capital",
+            "symbols", "portfolio", "min_bars_required",
+            "strategies", "allocation_per_trade", "execution_time",
+            "slippage_pct", "commission_per_share", "risk_free_rate",
+            "htb_rate_annual", "max_pct_adv", "volume_impact_coeff",
+            "stop_tokens",
+            "min_pandl_to_show_in_summary", "max_acceptable_drawdown",
+            "mc_score_min_to_show_in_summary", "min_performance_vs_spy",
+            "num_mc_simulations", "min_trades_for_mc", "mc_sampling",
+            "wfa_split_ratio", "wfa_folds",
+            "save_individual_trades", "save_only_filtered_trades",
+            "noise_injection_pct", "rolling_sharpe_window",
+            "export_ml_features", "upload_to_s3",
+            "overrides",
+        ]
+        for dest in expected_dests:
+            assert hasattr(args, dest), f"Expected dest '{dest}' missing from parser"
+
+    def test_no_args_leaves_all_none(self):
+        args = _parse([])
+        assert args.data_provider is None
+        assert args.start_date is None
+        assert args.initial_capital is None
+        assert args.symbols is None
+        assert args.overrides is None
+
+
+# ---------------------------------------------------------------------------
+# TestPrintHelpConfig
+# ---------------------------------------------------------------------------
+
+class TestPrintHelpConfig:
+    def _capture(self, cfg, category=None) -> str:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            print_help_config(cfg, category)
+        return buf.getvalue()
+
+    def test_full_print_contains_all_section_titles(self):
+        out = self._capture(_cfg())
+        assert "DATA" in out
+        assert "PERIOD" in out
+        assert "MONTE CARLO" in out
+        assert "WALK-FORWARD" in out
+        assert "STOP LOSS" in out
+
+    def test_full_print_shows_current_value(self):
+        cfg = _cfg(start_date="2015-01-01")
+        out = self._capture(cfg)
+        assert "2015-01-01" in out
+
+    def test_category_data_excludes_mc(self):
+        out = self._capture(_cfg(), category="data")
+        assert "--provider" in out
+        assert "MONTE CARLO" not in out
+
+    def test_category_mc_contains_mc_section(self):
+        out = self._capture(_cfg(), category="mc")
+        assert "--mc-sims" in out
+        assert "--mc-sampling" in out
+
+    def test_category_wfa_contains_wfa_section(self):
+        out = self._capture(_cfg(), category="wfa")
+        assert "--wfa-split" in out
+        assert "--wfa-folds" in out
+
+    def test_unknown_category_shows_error_and_valid_list(self):
+        out = self._capture(_cfg(), category="banana")
+        assert "Unknown category" in out
+        assert "data" in out  # lists valid ones
+
+    def test_all_valid_categories_print_without_error(self):
+        for cat in VALID_CATEGORIES:
+            out = self._capture(_cfg(), category=cat)
+            assert len(out) > 50, f"Category {cat!r} produced suspiciously short output"
+
+    def test_no_category_arg_prints_everything(self):
+        out = self._capture(_cfg(), category=None)
+        assert "DATA" in out
+        assert "OUTPUT" in out
+
+    def test_capital_formatted_with_commas(self):
+        cfg = _cfg(initial_capital=100_000.0)
+        out = self._capture(cfg, category="period")
+        assert "100,000" in out


### PR DESCRIPTION
## Overview

Add a fully-featured CLI config override system to `main.py` so users can tweak any common setting without editing `config.py`. Also add `--help-config` (and `--help-config <category>`) that prints a rich, living reference guide showing current defaults pulled directly from `config.py`.

---

## Motivation

Currently the only runtime flags are `--name`, `--dry-run`, and `--verbose`. Every setting change requires editing `config.py` manually. For quick experiments (different capital, date range, single ticker, stop-loss variant) this is friction. A CLI layer lets users iterate without touching files.

---

## New Flags (35 named + 1 escape hatch)

### Data
| Flag | Config key | Type | Notes |
|------|-----------|------|-------|
| `--provider` | `data_provider` | str | `norgate\|yahoo\|polygon\|csv\|parquet` |
| `--csv-dir` | `csv_data_dir` | str | path, only used when `--provider csv` |
| `--parquet-dir` | `parquet_data_dir` | str | path, only used when `--provider parquet` |

### Period & Capital
| Flag | Config key | Type | Notes |
|------|-----------|------|-------|
| `--start` | `start_date` | str | YYYY-MM-DD |
| `--end` | `end_date` | str | YYYY-MM-DD |
| `--capital` | `initial_capital` | float | USD, no commas |

### Portfolio & Symbols
| Flag | Config key | Type | Notes |
|------|-----------|------|-------|
| `--symbols` | `portfolios` | str+ | inline list, builds `{"CLI": ["AAPL","MSFT"]}` |
| `--portfolio` | `portfolios` | str | JSON filename, builds `{"CLI": "nasdaq_100.json"}` |
| `--min-bars` | `min_bars_required` | int | skip symbols with fewer bars |

### Strategies
| Flag | Config key | Type | Notes |
|------|-----------|------|-------|
| `--strategies` | `strategies` | str+ | exact names; use `all` to run everything |

### Execution & Costs
| Flag | Config key | Type | Notes |
|------|-----------|------|-------|
| `--allocation` | `allocation_per_trade` | float | e.g. 0.05 = 5% per position |
| `--execution` | `execution_time` | str | `open` or `close` |
| `--slippage` | `slippage_pct` | float | e.g. 0.001 |
| `--commission` | `commission_per_share` | float | e.g. 0.005 |
| `--risk-free-rate` | `risk_free_rate` | float | annual, e.g. 0.04 |
| `--htb-rate` | `htb_rate_annual` | float | annual borrow cost for shorts |
| `--max-pct-adv` | `max_pct_adv` | float | max fraction of 20d ADV per order |
| `--volume-impact` | `volume_impact_coeff` | float | sqrt market impact coefficient |

### Stop Loss
| Flag | Config key | Type | Notes |
|------|-----------|------|-------|
| `--stop` | `stop_loss_configs` | str+ | shorthand: `none`, `pct:0.05`, `atr:14:3.0` |

Stop shorthand parsing rules:
- `none` -> `{"type": "none"}`
- `pct:0.05` -> `{"type": "percentage", "value": 0.05}`
- `atr:14:3.0` -> `{"type": "atr", "period": 14, "multiplier": 3.0}`

### Filtering
| Flag | Config key | Type | Notes |
|------|-----------|------|-------|
| `--min-pandl` | `min_pandl_to_show_in_summary` | float | |
| `--max-dd` | `max_acceptable_drawdown` | float | |
| `--min-mc-score` | `mc_score_min_to_show_in_summary` | float | |
| `--min-vs-spy` | `min_performance_vs_spy` | float | |

### Monte Carlo
| Flag | Config key | Type | Notes |
|------|-----------|------|-------|
| `--mc-sims` | `num_mc_simulations` | int | |
| `--min-trades-mc` | `min_trades_for_mc` | int | |
| `--mc-sampling` | `mc_sampling` | str | `iid` or `block` |

### Walk-Forward Analysis
| Flag | Config key | Type | Notes |
|------|-----------|------|-------|
| `--wfa-split` | `wfa_split_ratio` | float | 0.0 disables WFA |
| `--wfa-folds` | `wfa_folds` | int | 0 disables rolling WFA |

### Output & Misc
| Flag | Config key | Type | Notes |
|------|-----------|------|-------|
| `--save-trades` / `--no-save-trades` | `save_individual_trades` | bool | |
| `--save-filtered-only` / `--no-save-filtered-only` | `save_only_filtered_trades` | bool | |
| `--noise` | `noise_injection_pct` | float | 0.0 = disabled |
| `--rolling-sharpe` | `rolling_sharpe_window` | int | 0 = disabled |
| `--export-ml` / `--no-export-ml` | `export_ml_features` | bool | |
| `--upload-s3` / `--no-upload-s3` | `upload_to_s3` | bool | |

### Escape Hatch
| Flag | Notes |
|------|-------|
| `--set key=value` | Override any config key not covered by a named flag. Value auto-cast: int -> int, float -> float, true/false -> bool, else str. Repeatable. |

---

## `--help-config` Guided Tour

### Usage
```
python main.py --help-config              # full guide, all categories
python main.py --help-config data         # just DATA section
python main.py --help-config costs        # EXECUTION & COSTS section
python main.py --help-config wfa          # WFA section
python main.py --help-config filtering    # FILTERING section
python main.py --help-config mc           # MONTE CARLO section
python main.py --help-config portfolio    # PORTFOLIO & SYMBOLS section
python main.py --help-config output       # OUTPUT & MISC section
```

### Output format (example)
```
+==============================================================+
|           july-backtester  --  Config Reference              |
+==============================================================+

  DATA  --------------------------------------------------------
  --provider <str>
      Which data source to use.
      Current : norgate
      Options : norgate | yahoo | polygon | csv | parquet
      Example : python main.py --provider yahoo

  --csv-dir <path>
      Folder containing per-symbol CSV files (provider=csv only).
      Current : csv_data
      Example : python main.py --provider csv --csv-dir ./my_data

  PERIOD & CAPITAL  --------------------------------------------
  --start <YYYY-MM-DD>
      Backtest start date.
      Current : 2004-01-01
      Example : python main.py --start 2015-01-01

  --capital <float>
      Starting equity in USD.
      Current : 100,000
      Example : python main.py --capital 50000
```

Valid category names (argument to `--help-config`):
`data`, `period`, `portfolio`, `strategies`, `costs`, `stop`, `filtering`, `mc`, `wfa`, `output`

---

## Files Changed

### New: `helpers/cli_config.py`
Pure module, no side-effects. Contains:
- `build_parser() -> argparse.ArgumentParser`
- `apply_overrides(config_dict: dict, args: argparse.Namespace) -> dict`
- `parse_stop_token(token: str) -> dict`
- `cast_value(s: str) -> int | float | bool | str`
- `print_help_config(config_dict: dict, category: str | None)`

### Modified: `main.py`
- Import `build_parser`, `apply_overrides`, `print_help_config` from `helpers.cli_config`
- Replace existing argparse block with `parser = build_parser()`
- Handle `--help-config` immediately after `args = parser.parse_args()` (print + exit)
- Call `apply_overrides(CONFIG, args)` before any downstream import reads CONFIG
- All existing flags (`--name`, `--dry-run`, `--verbose`) unchanged

### New: `tests/test_cli_config.py`

#### TestParseStopToken (5 tests)
- `none` -> `{"type": "none"}`
- `pct:0.05` -> `{"type": "percentage", "value": 0.05}`
- `atr:14:3.0` -> `{"type": "atr", "period": 14, "multiplier": 3.0}`
- Invalid token raises ValueError
- Case-insensitive (`PCT:0.05` works)

#### TestCastValue (5 tests)
- `"42"` -> `42` (int)
- `"3.14"` -> `3.14` (float)
- `"true"` / `"false"` -> `True` / `False` (bool)
- `"norgate"` -> `"norgate"` (str passthrough)

#### TestApplyOverrides (18 tests)
- `--provider yahoo` sets `data_provider`
- `--start 2018-01-01` sets `start_date`
- `--capital 75000` sets `initial_capital`
- `--symbols AAPL MSFT` sets `portfolios = {"CLI": ["AAPL", "MSFT"]}`
- `--portfolio nasdaq_100.json` sets `portfolios = {"CLI": "nasdaq_100.json"}`
- `--strategies "SMA Crossover (20d/50d)"` sets strategies list
- `--strategies all` sets `strategies = "all"`
- `--allocation 0.05` sets `allocation_per_trade`
- `--stop none pct:0.05` builds two-element stop_loss_configs list
- `--min-pandl 10.0` sets filter
- `--max-dd 0.30` sets filter
- `--mc-sims 500` sets `num_mc_simulations`
- `--wfa-split 0.70` sets `wfa_split_ratio`
- `--wfa-split 0` sets `wfa_split_ratio = None` (disables WFA)
- `--no-save-trades` sets `save_individual_trades = False`
- `--export-ml` sets `export_ml_features = True`
- `--set noise_injection_pct=0.01` sets via escape hatch
- `--set wfa_folds=5` sets int via escape hatch

#### TestBuildParser (3 tests)
- `build_parser()` returns an ArgumentParser
- `--help-config` flag present
- All expected dest names present

#### TestPrintHelpConfig (4 tests)
- Full print (no category) does not raise, output contains "DATA"
- `category="data"` contains DATA section, does not contain "MONTE CARLO"
- `category="mc"` contains MC section
- Unknown category prints error listing valid categories

---

## Example Commands After This Change

```bash
# Quick single-ticker run on Yahoo
python main.py --provider yahoo --symbols AAPL --start 2020-01-01 --capital 25000

# Scan Nasdaq 100, filter to strategies beating SPY
python main.py --portfolio nasdaq_100.json --min-vs-spy 0.0

# Stress test with noise + block-bootstrap MC
python main.py --noise 0.01 --mc-sampling block --mc-sims 2000

# Run multiple stop variants
python main.py --stop pct:0.05 pct:0.10 atr:14:3.0

# Override an obscure key via escape hatch
python main.py --set rolling_sharpe_window=252 --set htb_rate_annual=0.15

# See full config guide
python main.py --help-config

# See just WFA options
python main.py --help-config wfa
```

---

## Acceptance Criteria
- [ ] All 35 named flags override correct config keys
- [ ] `--symbols` and `--portfolio` are mutually exclusive
- [ ] `--stop` accepts multiple tokens and builds correct list of dicts
- [ ] `--wfa-split 0` sets `wfa_split_ratio = None` (disables WFA)
- [ ] `--help-config` prints without error in all category modes
- [ ] `--help-config` shows live current values from config.py
- [ ] Existing flags (`--name`, `--dry-run`, `--verbose`) unchanged
- [ ] `python -m pytest tests/test_cli_config.py` all pass
- [ ] Full suite `python -m pytest tests/ -q` no regressions
