### PR TITLE
docs: update README CLI Flags section for #117 config override system

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,13 +182,135 @@ graph TD
 
 ## CLI Flags
 
+Every setting in `config.py` can be overridden at runtime — no file editing required.
+
+### Built-in flags
+
 | Flag | Description |
 | --- | --- |
 | *(none)* | Full backtest run |
 | `--init` | Launch the first-time setup wizard |
 | `--dry-run` | Validate config and print run summary without fetching data |
 | `--name <label>` | Prefix the output folder with a custom label |
-| `--verbose` | Print Extended Metrics and Robustness tables beneath the default Core Performance table |
+| `--verbose` | Print Extended Metrics and Robustness tables |
+| `--help-config [category]` | Print a guided tour of all config options with live defaults |
+
+### Config override flags
+
+Pass any of these to override `config.py` for a single run:
+
+**Data**
+```
+--provider <str>          norgate | yahoo | polygon | csv | parquet
+--csv-dir <path>          CSV folder (--provider csv only)
+--parquet-dir <path>      Parquet folder (--provider parquet only)
+```
+
+**Period & Capital**
+```
+--start <YYYY-MM-DD>      Backtest start date
+--end   <YYYY-MM-DD>      Backtest end date
+--capital <float>         Starting equity in USD
+```
+
+**Portfolio & Symbols** *(mutually exclusive)*
+```
+--symbols AAPL MSFT …     Inline ticker list → runs as 'CLI' portfolio
+--portfolio nasdaq_100.json   JSON file or norgate:WatchlistName
+--min-bars <int>          Skip symbols with fewer bars
+```
+
+**Strategies**
+```
+--strategies "Name 1" "Name 2"   Exact strategy names to run
+--strategies all                 Run every registered strategy
+```
+
+**Execution & Costs**
+```
+--allocation <float>      Fraction of equity per position (e.g. 0.05)
+--execution open|close    Fill time
+--slippage <float>        Bid/ask slippage fraction
+--commission <float>      Commission per share in USD
+--risk-free-rate <float>  Annual risk-free rate for Sharpe
+--htb-rate <float>        Annual hard-to-borrow rate for shorts
+--max-pct-adv <float>     Max fraction of 20d ADV per order
+--volume-impact <float>   Sqrt market-impact coefficient (0 = off)
+```
+
+**Stop Loss** *(repeatable)*
+```
+--stop none               No stop
+--stop pct:0.05           5% percentage stop
+--stop atr:14:3.0         ATR stop (period=14, multiplier=3.0)
+--stop pct:0.05 atr:14:3.0   Run both variants in one pass
+```
+
+**Filtering**
+```
+--min-pandl <float>       Min P&L % to show (-9999 = show all)
+--max-dd <float>          Max drawdown to show (1.0 = show all)
+--min-mc-score <float>    Min MC score to show
+--min-vs-spy <float>      Min outperformance vs SPY
+```
+
+**Monte Carlo**
+```
+--mc-sims <int>           Number of MC simulations
+--min-trades-mc <int>     Min trades required to run MC
+--mc-sampling iid|block   Resampling method
+```
+
+**Walk-Forward Analysis**
+```
+--wfa-split <float>       In-sample fraction (0 = disable WFA)
+--wfa-folds <int>         Rolling WFA folds (0 = disable)
+```
+
+**Output & Misc**
+```
+--save-trades / --no-save-trades
+--save-filtered-only / --no-save-filtered-only
+--noise <float>           OHLC noise injection fraction (0 = off)
+--rolling-sharpe <int>    Rolling Sharpe window in bars (0 = off)
+--export-ml / --no-export-ml
+--upload-s3 / --no-upload-s3
+```
+
+**Escape hatch — any config key not covered above**
+```
+--set KEY=VALUE           Auto-cast to int/float/bool/str. Repeatable.
+  e.g.  --set rolling_sharpe_window=252 --set htb_rate_annual=0.15
+```
+
+### Guided help
+
+```bash
+python main.py --help-config              # full reference with live defaults
+python main.py --help-config data         # DATA section only
+python main.py --help-config wfa          # WFA section only
+# categories: data, period, portfolio, strategies, costs, stop,
+#             filtering, mc, wfa, output
+```
+
+### Example commands
+
+```bash
+# Quick single-ticker run on Yahoo Finance
+python main.py --provider yahoo --symbols AAPL --start 2020-01-01 --capital 25000
+
+# Scan Nasdaq 100, only show strategies that beat SPY
+python main.py --portfolio nasdaq_100.json --min-vs-spy 0.0
+
+# Test three stop-loss variants in one pass
+python main.py --stop none pct:0.05 atr:14:3.0
+
+# Stress test with noise + block-bootstrap MC
+python main.py --noise 0.01 --mc-sampling block --mc-sims 2000
+
+# Override keys not covered by a named flag
+python main.py --set rolling_sharpe_window=252 --set htb_rate_annual=0.15
+```
 
 ---
 


### PR DESCRIPTION
Replaces the old 5-flag table with full documentation for all 35 named flags, `--set` escape hatch, `--help-config` guided tour, and example commands. Closes #117 docs gap.