### PR TITLE
fix: validate cache start date to detect plan-capped provider data (#123)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,11 +225,11 @@ Called inside `get_price_data` before constructing `yf.Ticker(yahoo_symbol)`. Te
 
 The `TestU1SummaryContent::test_period_selected_label_is_exact` test enforces that every log line containing "Period" also contains "Selected" (no bare `Period :` label remains).
 
-### Polygon API Plan Limitation — Root Cause of 71% vs 814% Discrepancy
+### Polygon API Plan Limitation & Cache Validation Bug
 
-**Diagnostic (`debug_data.py`)**: Polygon returns 1,254 bars starting 2021-03-12. Yahoo returns 5,581 bars starting 2004-01-02. The SPY return difference (+742 pp) is 100% explained by the ~17-year start-date gap — Polygon's API plan (starter tier) limits history to roughly the last 5 years. There is NO pagination bug in `polygon_service.py` — the single page with 50,000-bar limit returns all available bars correctly. This is a hard server-side constraint; upgrading the Polygon plan is the only fix.
+**Plan history caps**: Polygon limits available history based on plan tier. A starter plan capped at ~2021; a paid plan extends that (confirmed: ~2016 on current plan). The `Actual Data Period` line in the run summary shows the true start Polygon returned — if it lags the configured `start_date`, the plan tier is the constraint. There is no pagination bug in `polygon_service.py` — the single page with 50,000-bar limit returns all available bars correctly.
 
-**Key implication**: When using Polygon, `Actual Data Period` in the run summary will show the true start, making it visible that the configured `start_date` of 2004 is not honoured.
+**Cache validation bug (issue #123)**: The local Parquet cache keys data by *requested* date range, not actual returned range. If Polygon returns plan-capped data (e.g. 2016–now) for a 2004 request, the cache stores that truncated result under a key named `SPY_2004-01-01_..._day_1.parquet`. After a plan upgrade, subsequent runs still serve the old capped data from cache — silently — until the cache entry is manually deleted or expires. **Fix**: add start-date validation in the `helpers/caching.py` read path; if `df.index.min()` lags the requested start by >30 days, treat as a cache miss and re-fetch. See issue #123 for the full implementation spec.
 
 ### S1/S2 Test Robustness
 

--- a/helpers/caching.py
+++ b/helpers/caching.py
@@ -35,7 +35,23 @@ def get_cached_data(symbol: str, start: str, end: str, timeframe: str, multiplie
         if datetime.now() - file_mod_time < timedelta(hours=CACHE_TTL_HOURS):
             logger.debug(f"  -> Cache HIT for '{symbol}'. Loading from '{filepath}'.")
             try:
-                return pd.read_parquet(filepath)
+                df = pd.read_parquet(filepath)
+                # Validate that cached data actually covers the requested start date.
+                # A provider may have returned plan-capped data (e.g. only 5 years) for
+                # a longer request, storing truncated rows under the full-range cache key.
+                # After a plan upgrade the cache would silently serve the old capped data.
+                requested_start = pd.Timestamp(start).tz_localize("UTC")
+                cache_start = df.index.min()
+                if hasattr(cache_start, "tzinfo") and cache_start.tzinfo is None:
+                    cache_start = cache_start.tz_localize("UTC")
+                lag_days = (cache_start - requested_start).days
+                if lag_days > 30:
+                    logger.warning(
+                        f"  -> Cache STALE for '{symbol}': cached start {cache_start.date()} "
+                        f"lags requested {start} by {lag_days} days — discarding and re-fetching."
+                    )
+                    return None
+                return df
             except Exception as e:
                 logger.warning(f"Could not read cache file '{filepath}'. Will re-fetch. Error: {e}")
                 return None


### PR DESCRIPTION
## Summary

- Adds start-date validation to the `get_cached_data` read path in `helpers/caching.py`
- If a cached file's actual first row lags the requested start date by more than 30 days, the cache entry is discarded and a fresh fetch is forced
- Prevents silently serving stale plan-limited data after a provider plan upgrade

## Root Cause

The cache key is built from the *requested* date range, not what the provider actually returned. When Polygon (or any provider) caps history at a plan tier boundary, the truncated DataFrame is stored under a key that looks like full coverage — e.g. `SPY_2004-01-01_2026-04-21_day_1.parquet` containing only 2016–2026 data. Upgrading the plan has zero effect until the cache TTL expires or the file is manually deleted.

Confirmed live: deleting the stale Polygon cache files revealed data starting 2016-04-25 instead of the expected 2021-03-12, proving the plan was already upgraded but the cache was masking it.

## Change

```python
# helpers/caching.py — get_cached_data(), after pd.read_parquet()
requested_start = pd.Timestamp(start).tz_localize("UTC")
cache_start = df.index.min()
if hasattr(cache_start, "tzinfo") and cache_start.tzinfo is None:
    cache_start = cache_start.tz_localize("UTC")
lag_days = (cache_start - requested_start).days
if lag_days > 30:
    logger.warning(
        f"  -> Cache STALE for '{symbol}': cached start {cache_start.date()} "
        f"lags requested {start} by {lag_days} days — discarding and re-fetching."
    )
    return None
```

## Threshold Rationale

30 days tolerates legitimate gaps — a stock that IPO'd a few weeks after the configured `start_date` will have a cache start that lags by days or weeks, which is expected. Multi-month or multi-year lags caused by plan caps or data availability limits are caught and invalidated.

## Test Plan

- [x] All 1054 existing tests pass (`pytest tests/ -x -q`)
- [x] No new tests required — this is a read-path guard with no new public API surface; the existing caching integration is covered by the live provider tests

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)