### PR TITLE
feat(momentum-rotation): weekly rebalance trim — cap position drift from 20% target

### DIFF
--- a/scripts/momentum_rotation_v2.py
+++ b/scripts/momentum_rotation_v2.py
@@ -284,6 +284,42 @@ def run_backtest(all_data: dict, qqq_df: pd.DataFrame, rebalance_pairs: list):
             if r > SELL_BUFFER_RANK:
                 do_sell(sym, exec_date, f"Rank {r} > {SELL_BUFFER_RANK}")
 
+        # Trim positions that have drifted above target allocation
+        for sym, pos in list(positions.items()):
+            current_price = get_price(all_data[sym], exec_date, "Open")
+            if np.isnan(current_price) or current_price <= 0:
+                continue
+            current_value  = pos["shares"] * current_price
+            target_value   = alloc_equity * ALLOCATION_PCT
+            if MAX_POSITION_SIZE is not None:
+                target_value = min(target_value, MAX_POSITION_SIZE)
+            excess_value   = current_value - target_value
+            if excess_value <= 0:
+                continue
+            trim_shares = math.floor(excess_value / current_price)
+            if trim_shares <= 0:
+                continue
+            exit_price = current_price * (1 - SLIPPAGE_SELL)
+            commission = trim_shares * COMMISSION_PER_SHR
+            proceeds   = trim_shares * exit_price - commission
+            trim_cost  = pos["cost_basis"] * (trim_shares / pos["shares"])
+            pnl        = proceeds - trim_cost
+            trade_log.append({
+                "Symbol":     sym,
+                "EntryDate":  pos["entry_date"],
+                "ExitDate":   exec_date,
+                "EntryPrice": round(pos["entry_price"], 4),
+                "ExitPrice":  round(exit_price, 4),
+                "Shares":     trim_shares,
+                "PnL":        round(pnl, 2),
+                "PnLPct":     round(pnl / trim_cost * 100, 2) if trim_cost > 0 else 0.0,
+                "HoldDays":   (exec_date - pos["entry_date"]).days,
+                "ExitReason": "Trim",
+            })
+            cash += proceeds
+            pos["shares"]     -= trim_shares
+            pos["cost_basis"] -= trim_cost
+
         slots = MAX_POSITIONS - len(positions)
         for sym in ranked:
             if slots <= 0:

--- a/tests/test_rebalance_trim.py
+++ b/tests/test_rebalance_trim.py
@@ -1,0 +1,118 @@
+# tests/test_rebalance_trim.py
+"""
+Tests for trim-on-rebalance logic (issue #137).
+"""
+
+import importlib.util
+import os
+import sys
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+_spec = importlib.util.spec_from_file_location(
+    "momentum_rotation_v2",
+    os.path.join(PROJECT_ROOT, "scripts", "momentum_rotation_v2.py"),
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+run_backtest          = _mod.run_backtest
+build_rebalance_pairs = _mod.build_rebalance_pairs
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_with_drift(initial_price, drifted_price, cap=None):
+    """
+    Week 1: buy at initial_price.
+    Week 2: open at drifted_price → trim fires if position > target.
+    """
+    dates = pd.date_range("2020-01-02", periods=20, freq="B")
+    qqq_closes = list(range(100, 120))
+    qqq_df = pd.DataFrame(
+        {"Open": qqq_closes, "High": [c * 1.01 for c in qqq_closes],
+         "Low":  [c * 0.99 for c in qqq_closes], "Close": qqq_closes,
+         "Volume": 1_000_000},
+        index=dates,
+    )
+    mid    = len(dates) // 2
+    prices = [initial_price] * mid + [drifted_price] * (len(dates) - mid)
+    sym_df = pd.DataFrame(
+        {"Open": prices, "High": [p * 1.01 for p in prices],
+         "Low":  [p * 0.99 for p in prices], "Close": prices, "Volume": 1_000_000},
+        index=dates,
+    )
+    all_data = {"A": sym_df}
+    pairs    = build_rebalance_pairs({"A": sym_df, "QQQ": qqq_df})
+
+    with patch.object(_mod, "REGIME_MA_PERIOD", 5), \
+         patch.object(_mod, "MOMENTUM_LOOKBACK", 5), \
+         patch.object(_mod, "SELL_BUFFER_RANK", 999), \
+         patch.object(_mod, "MAX_POSITIONS", 1), \
+         patch.object(_mod, "INITIAL_CAPITAL", 100_000.0), \
+         patch.object(_mod, "MAX_POSITION_SIZE", cap):
+        trade_log, _ = run_backtest(all_data, qqq_df, pairs[:3])
+
+    return trade_log
+
+
+# ---------------------------------------------------------------------------
+# TestRebalanceTrim
+# ---------------------------------------------------------------------------
+
+class TestRebalanceTrim:
+    """Verify trim-on-rebalance logic (issue #137)."""
+
+    def test_trim_fires_when_position_drifts_above_target(self):
+        # Buy at $10 (20% of $100k = $2k), next week open at $50 → trim fires
+        tl = _run_with_drift(initial_price=10.0, drifted_price=50.0)
+        assert any(t["ExitReason"] == "Trim" for t in tl), "expected a trim trade"
+
+    def test_no_trim_when_position_at_or_below_target(self):
+        # Flat price → position stays at target → no trim
+        tl = _run_with_drift(initial_price=10.0, drifted_price=10.0)
+        assert not any(t["ExitReason"] == "Trim" for t in tl), "expected no trim on flat price"
+
+    def test_trim_is_profitable_on_appreciated_position(self):
+        tl = _run_with_drift(initial_price=10.0, drifted_price=50.0)
+        trims = [t for t in tl if t["ExitReason"] == "Trim"]
+        assert trims
+        assert all(t["PnL"] > 0 for t in trims), "trim on appreciated position should be profitable"
+
+    def test_nan_open_price_skips_trim_gracefully(self):
+        dates = pd.date_range("2020-01-02", periods=20, freq="B")
+        qqq_closes = list(range(100, 120))
+        qqq_df = pd.DataFrame(
+            {"Open": qqq_closes, "High": [c * 1.01 for c in qqq_closes],
+             "Low":  [c * 0.99 for c in qqq_closes], "Close": qqq_closes,
+             "Volume": 1_000_000},
+            index=dates,
+        )
+        opens  = [10.0] * 10 + [np.nan] * 10
+        closes = [50.0] * 20
+        sym_df = pd.DataFrame(
+            {"Open": opens, "High": closes, "Low": closes, "Close": closes, "Volume": 1_000_000},
+            index=dates,
+        )
+        all_data = {"A": sym_df}
+        pairs    = build_rebalance_pairs({"A": sym_df, "QQQ": qqq_df})
+
+        with patch.object(_mod, "REGIME_MA_PERIOD", 5), \
+             patch.object(_mod, "MOMENTUM_LOOKBACK", 5), \
+             patch.object(_mod, "SELL_BUFFER_RANK", 999), \
+             patch.object(_mod, "MAX_POSITIONS", 1), \
+             patch.object(_mod, "INITIAL_CAPITAL", 100_000.0), \
+             patch.object(_mod, "MAX_POSITION_SIZE", None):
+            trade_log, _ = run_backtest(all_data, qqq_df, pairs[:3])
+
+        assert not any(t["ExitReason"] == "Trim" for t in trade_log), \
+            "NaN open price should skip trim without crashing"


### PR DESCRIPTION
## Summary

- At each weekly rebalance, sells excess shares back to target allocation when a position's market value drifts above target
- Trim fires **after** rank-based sells and **before** new buys, so freed cash is immediately available for new slots
- Respects `MAX_POSITION_SIZE` cap (from #136) when computing the target value
- `ExitReason: "Trim"` in the trade log

## Test plan

- [x] `test_trim_fires_when_position_drifts_above_target` — price 5× → trim fires
- [x] `test_no_trim_when_position_at_or_below_target` — flat price → no trim
- [x] `test_trim_is_profitable_on_appreciated_position` — trim PnL > 0
- [x] `test_nan_open_price_skips_trim_gracefully` — NaN open → no crash, no trim

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)