### PR TITLE
fix(indicators): add missing calculate_williams_r function

### DIFF
--- a/helpers/indicators.py
+++ b/helpers/indicators.py
@@ -1243,3 +1243,9 @@ def ema_crossover_vix_only_logic(df, vix_df, fast_ema, slow_ema, vix_threshold=3
     df['Signal'] = np.where((original_signal == 1) & is_market_calm, 1, original_signal)
     df['Signal'] = df['Signal'].replace(0, np.nan).ffill().fillna(0)
     return df
+
+def calculate_williams_r(df, period=14):
+    highest_high = df['High'].rolling(window=period).max()
+    lowest_low = df['Low'].rolling(window=period).min()
+    df[f'WilliamsR_{period}'] = -100 * (highest_high - df['Close']) / (highest_high - lowest_low + 1e-10)
+    return df


### PR DESCRIPTION
## Summary

- `calculate_williams_r` was missing from `helpers/indicators.py`, causing a `KeyError: 'WilliamsR_{period}'` at runtime for any strategy that calls this function (e.g. EC-VIX and smooth-curve strategy families)
- Added the implementation using the standard Williams %%R formula: `-100 × (highest_high - close) / (highest_high - lowest_low)`
- Column name follows the existing convention: `WilliamsR_{period}`
- Also fixes a missing newline at end of file

## Test plan

- [ ] Run any EC-VIX strategy (e.g. `EC-VIX-8`, `EC-VIX-10`) — previously crashed with `KeyError: 'WilliamsR_70'`, now completes successfully
- [ ] Run `EC-R70`, `EC-R71`, `EC-TLT-2` — same fix applies
- [ ] Confirm `helpers/indicators.py` exports `calculate_williams_r` and column naming matches `WilliamsR_{period}` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)