### PR TITLE
Add point-in-time universe portfolio support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pandas "numpy<2.0" tqdm boto3 requests python-dotenv orjson pyarrow yfinance matplotlib seaborn pytest
+          pip install pandas "numpy<2.0" tqdm boto3 requests python-dotenv PyYAML orjson pyarrow yfinance matplotlib seaborn pytest
           pip install pandas-ta
 
       - name: Run tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ helpers/wfa_rolling.py             # Rolling multi-fold WFA (get_fold_dates, eva
 helpers/ml_export.py               # ML trade feature export (export_trade_features)
 helpers/sensitivity.py             # Parameter sensitivity sweep (build_param_grid, label_for_params, is_sweep_enabled)
 helpers/regime.py                  # VIX regime heatmap (build_regime_heatmap, print_regime_heatmap, classify_vix_regime)
+helpers/point_in_time.py           # Point-in-time index universe resolver for portfolios like "pit:nq100" and "pit:sp500"
 helpers/init_wizard.py             # First-time setup wizard invoked via python main.py --init
 helpers/correlation.py             # Strategy correlation matrix (run_correlation_analysis, compute_avg_correlations)
 helpers/caching.py                 # Local Parquet cache (24h TTL)
@@ -64,6 +65,8 @@ scripts/debug_data.py              # Compares Polygon vs Yahoo SPY data; run wit
 "timeframe_multiplier": 1          # e.g. 5 for 5-min bars
 "portfolios": {"My Symbols": ["AAPL"]}             # single ticker (replaces old symbols_to_test)
 "portfolios": {"Nasdaq 100": "nasdaq_100.json"}  # pre-built JSON list
+"portfolios": {"Nasdaq 100 PIT": "pit:nq100"}    # point-in-time members as of start_date
+"portfolios": {"S&P 500 PIT": "pit:sp500"}       # requires PIT YAML files or SP500_DATA_ROOT
 "allocation_per_trade": 0.10       # 10% equity per position
 "stop_loss_configs": [{"type": "none"}]  # or {"type":"percentage","value":0.05}
 "slippage_pct": 0.0005

--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ The engine runs every strategy in `custom_strategies/` against SPY, prints a res
 },
 ```
 
+**Point-in-time index universe** — resolve S&P 500 or Nasdaq 100 membership as of `start_date`:
+
+```python
+"portfolios": {
+    "Nasdaq 100 PIT": "pit:nq100",
+    "S&P 500 PIT": "pit:sp500",
+},
+```
+
+Place PIT YAML files under `tickers_to_scan/point_in_time/`, or set `NQ100_DATA_ROOT` / `SP500_DATA_ROOT`.
+
 Validate before a long run: `python main.py --dry-run`
 
 See [examples/](examples/) for ready-to-use config files and annotated strategy examples.

--- a/config.py
+++ b/config.py
@@ -364,6 +364,22 @@ CONFIG = {
     # False (default) = include EoB mark-to-market closes (original behaviour)
     # True            = realized trades only; EoB positions are dropped
     "exclude_open_positions": False,
+
+    # ============================================================
+    # SECTION 23: POINT-IN-TIME UNIVERSE PATHS
+    # ============================================================
+    # Absolute paths to local clones of the PIT data repos.
+    # Required when using "pit:nq100" or "pit:sp500" as a portfolio value.
+    # Leave as "" to fall back to the NQ100_DATA_ROOT / SP500_DATA_ROOT
+    # environment variables, or drop the YAML files directly into:
+    #   tickers_to_scan/point_in_time/nq100/
+    #   tickers_to_scan/point_in_time/sp500/
+    #
+    # Repos:
+    #   NQ100 — https://github.com/shardul0701/NQ100-Survivorship-bias-data-2004-2026
+    #   SP500 — https://github.com/shardul0701/SP500-Survivorship-bias-data-2004-2026
+    "nq100_pit_path": r"c:\Users\shard\Light Water Internship\NQ100-Survivorship-bias-data-2004-2026",
+    "sp500_pit_path": r"c:\Users\shard\Light Water Internship\SP500-Survivorship-bias-data-2004-2026",
 }
 
 if CONFIG.get("data_provider") == "norgate":  # noqa: SIM102

--- a/helpers/config_validator.py
+++ b/helpers/config_validator.py
@@ -91,6 +91,9 @@ KNOWN_KEYS: set[str] = {
     "verbose_output",
     # SECTION 22: Realized-Only Reporting
     "exclude_open_positions",
+    # SECTION 23: Point-in-Time Universe Paths
+    "nq100_pit_path",
+    "sp500_pit_path",
     # S3
     "s3_reports_bucket",
     "upload_to_s3",

--- a/helpers/point_in_time.py
+++ b/helpers/point_in_time.py
@@ -40,9 +40,14 @@ PIT_TICKER_NORMALISATION = {
     # Common historical/modern symbol aliases seen in the public PIT repos and
     # price-provider stores. These are deliberately conservative; provider-level
     # ticker mapping remains a separate concern for deeper Norgate work.
+    #
+    # GOOG / GOOGL note: Google split into two share classes in April 2014.
+    # Post-split NQ100 YAML files list BOTH GOOG (Class C) and GOOGL (Class A)
+    # as distinct members. Mapping GOOG -> GOOGL would silently collapse them,
+    # dropping one position with no warning. The mapping is intentionally absent
+    # here; both symbols pass through unchanged.
     "PCLN": "BKNG",
     "HANS": "MNST",
-    "GOOG": "GOOGL",
 }
 
 
@@ -84,8 +89,6 @@ def _candidate_roots(index: str, config: dict | None = None) -> list[Path]:
     for name in INDEX_DIR_NAMES[index]:
         roots.append(pit_base / name)
 
-    if index == "nq100":
-        roots.append(ROOT / "NQ-SB" / "nasdaq100_point_in_time_universe_repo")
     roots.append(ROOT)
 
     seen: set[Path] = set()

--- a/helpers/point_in_time.py
+++ b/helpers/point_in_time.py
@@ -1,0 +1,179 @@
+"""Point-in-time index membership helpers.
+
+This module is the small public API used by the main backtester for
+survivorship-bias-free portfolio definitions such as ``pit:nq100`` and
+``pit:sp500``. It intentionally keeps static JSON portfolios unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+INDEX_ALIASES = {
+    "nq100": "nq100",
+    "nasdaq100": "nq100",
+    "nasdaq-100": "nq100",
+    "ndx": "nq100",
+    "sp500": "sp500",
+    "s&p500": "sp500",
+    "s&p-500": "sp500",
+    "s&p_500": "sp500",
+}
+
+INDEX_DIR_NAMES = {
+    "nq100": ["nq100", "nasdaq100", "nasdaq_100"],
+    "sp500": ["sp500", "sp-500", "s-and-p-500"],
+}
+
+INDEX_FILE_PREFIXES = {
+    "nq100": ["n100-ticker-changes", "nasdaq100-ticker-changes"],
+    "sp500": ["sp500-ticker-changes"],
+}
+
+PIT_TICKER_NORMALISATION = {
+    # Common historical/modern symbol aliases seen in the public PIT repos and
+    # price-provider stores. These are deliberately conservative; provider-level
+    # ticker mapping remains a separate concern for deeper Norgate work.
+    "PCLN": "BKNG",
+    "HANS": "MNST",
+    "GOOG": "GOOGL",
+}
+
+
+def _canonical_index(index: str) -> str:
+    key = str(index).strip().lower()
+    if key not in INDEX_ALIASES:
+        raise ValueError(f"Unknown PIT index '{index}'. Expected one of: nq100, sp500")
+    return INDEX_ALIASES[key]
+
+
+def normalise_pit_ticker(symbol: str, date: str | None = None) -> str:
+    """Return the ticker format expected by local price providers.
+
+    ``date`` is accepted for future date-aware mappings; current mappings are
+    stable aliases used by the available PIT repositories.
+    """
+    sym = str(symbol).strip().upper().replace(".", "-")
+    return PIT_TICKER_NORMALISATION.get(sym, sym)
+
+
+def _candidate_roots(index: str, config: dict | None = None) -> list[Path]:
+    config = config or {}
+    roots: list[Path] = []
+
+    if index == "sp500":
+        for key in ("sp500_pit_path", "sp500_data_root"):
+            if config.get(key):
+                roots.append(Path(config[key]))
+        if os.environ.get("SP500_DATA_ROOT"):
+            roots.append(Path(os.environ["SP500_DATA_ROOT"]))
+    else:
+        for key in ("nq100_pit_path", "nq100_data_root"):
+            if config.get(key):
+                roots.append(Path(config[key]))
+        if os.environ.get("NQ100_DATA_ROOT"):
+            roots.append(Path(os.environ["NQ100_DATA_ROOT"]))
+
+    pit_base = ROOT / "tickers_to_scan" / "point_in_time"
+    for name in INDEX_DIR_NAMES[index]:
+        roots.append(pit_base / name)
+
+    if index == "nq100":
+        roots.append(ROOT / "NQ-SB" / "nasdaq100_point_in_time_universe_repo")
+    roots.append(ROOT)
+
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for root in roots:
+        resolved = root.expanduser()
+        if resolved not in seen:
+            out.append(resolved)
+            seen.add(resolved)
+    return out
+
+
+def _yaml_dirs_for_root(root: Path, index: str) -> Iterable[Path]:
+    yield root
+    if index == "sp500":
+        yield root / "src" / "sp500_ticker_history"
+    else:
+        yield root / "src" / "nasdaq_100_ticker_history"
+        yield root / "src" / "nasdaq100_ticker_history"
+
+
+def _find_year_yaml(index: str, year: int, config: dict | None = None) -> Path:
+    prefixes = INDEX_FILE_PREFIXES[index]
+    for root in _candidate_roots(index, config):
+        for directory in _yaml_dirs_for_root(root, index):
+            if not directory.is_dir():
+                continue
+            for prefix in prefixes:
+                path = directory / f"{prefix}-{year}.yaml"
+                if path.exists():
+                    return path
+    raise FileNotFoundError(
+        f"No PIT YAML found for {index} {year}. Configure "
+        f"{'SP500_DATA_ROOT' if index == 'sp500' else 'NQ100_DATA_ROOT'} "
+        "or place files under tickers_to_scan/point_in_time/."
+    )
+
+
+@lru_cache(maxsize=512)
+def _load_year_yaml_cached(path_str: str) -> dict:
+    try:
+        import yaml
+    except ImportError as exc:
+        raise RuntimeError("PyYAML is required for point-in-time universe loading.") from exc
+
+    with open(path_str, encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def _load_year_yaml(path: Path) -> dict:
+    return _load_year_yaml_cached(str(path.resolve()))
+
+
+def tickers_as_of(index: str, date: str, config: dict | None = None) -> list[str]:
+    """Return the PIT members of ``index`` on ``date``.
+
+    Parameters
+    ----------
+    index:
+        ``"nq100"`` or ``"sp500"``.
+    date:
+        ISO date string. The membership includes changes effective on that date.
+    config:
+        Optional backtester config. Recognised path keys:
+        ``sp500_pit_path`` and ``nq100_pit_path``.
+    """
+    idx = _canonical_index(index)
+    qdate = str(date)[:10]
+    year = int(qdate[:4])
+    path = _find_year_yaml(idx, year, config)
+    data = _load_year_yaml(path)
+
+    members = {normalise_pit_ticker(t, qdate) for t in (data.get("tickers_on_Jan_1") or [])}
+    changes = data.get("changes") or {}
+    for change_date in sorted(str(d) for d in changes.keys()):
+        if change_date > qdate:
+            break
+        entry = changes[change_date] or {}
+        removed = {normalise_pit_ticker(t, change_date) for t in (entry.get("difference") or [])}
+        added = {normalise_pit_ticker(t, change_date) for t in (entry.get("union") or [])}
+        members = (members - removed) | added
+
+    return sorted(members)
+
+
+def resolve_pit_portfolio(value: str, config: dict) -> list[str] | None:
+    """Resolve ``pit:<index>`` portfolio values; return ``None`` otherwise."""
+    if not isinstance(value, str) or not value.startswith("pit:"):
+        return None
+    index = value.split(":", 1)[1]
+    return tickers_as_of(index, config["start_date"], config)

--- a/helpers/point_in_time.py
+++ b/helpers/point_in_time.py
@@ -3,10 +3,26 @@
 This module is the small public API used by the main backtester for
 survivorship-bias-free portfolio definitions such as ``pit:nq100`` and
 ``pit:sp500``. It intentionally keeps static JSON portfolios unchanged.
+
+Public API
+----------
+tickers_union_for_period(index, start_date, end_date, config)
+    Returns all tickers that were ever in the index between start_date and
+    end_date.  Use this to build a survivorship-bias-free ticker universe
+    that includes delisted / removed constituents.
+
+build_membership_schedule(index, start_date, end_date, config)
+    Returns a sorted list of (effective_date, frozenset_of_members) snapshots
+    covering [start_date, end_date].  Precompute once per portfolio; query
+    cheaply per date with pit_members_on().
+
+pit_members_on(schedule, date)
+    Binary-search the schedule for membership on an ISO date string.
 """
 
 from __future__ import annotations
 
+import bisect
 import os
 from functools import lru_cache
 from pathlib import Path
@@ -180,3 +196,138 @@ def resolve_pit_portfolio(value: str, config: dict) -> list[str] | None:
         return None
     index = value.split(":", 1)[1]
     return tickers_as_of(index, config["start_date"], config)
+
+
+# ---------------------------------------------------------------------------
+# Full-history union and membership schedule (survivorship-bias-free engine)
+# ---------------------------------------------------------------------------
+
+def tickers_union_for_period(
+    index: str,
+    start_date: str,
+    end_date: str,
+    config: dict | None = None,
+) -> list[str]:
+    """Return every ticker that was ever in *index* between *start_date* and *end_date*.
+
+    This builds a survivorship-bias-free universe: it includes companies that
+    were later removed, delisted, or acquired, as long as they were members of
+    the index at some point during the requested period.
+
+    Parameters
+    ----------
+    index       : ``"nq100"`` or ``"sp500"``
+    start_date  : ISO date string (``"2004-01-01"``)
+    end_date    : ISO date string (``"2026-01-01"``)
+    config      : Optional backtester config.  Recognised path keys:
+                  ``nq100_pit_path`` and ``sp500_pit_path``.
+
+    Returns
+    -------
+    list[str]
+        Sorted list of unique tickers.
+    """
+    idx = _canonical_index(index)
+    sy = int(start_date[:4])
+    ey = int(end_date[:4])
+    union: set[str] = set()
+    for year in range(sy, ey + 1):
+        try:
+            path = _find_year_yaml(idx, year, config)
+            data = _load_year_yaml(path)
+        except FileNotFoundError:
+            continue
+        union.update(normalise_pit_ticker(t) for t in (data.get("tickers_on_Jan_1") or []))
+        for entry in ((data.get("changes") or {}).values()):
+            if entry:
+                union.update(normalise_pit_ticker(t) for t in (entry.get("union") or []))
+    return sorted(union)
+
+
+def build_membership_schedule(
+    index: str,
+    start_date: str,
+    end_date: str,
+    config: dict | None = None,
+) -> list[tuple[str, frozenset]]:
+    """Build a sorted list of (effective_date, member_frozenset) snapshots.
+
+    The first entry always has ``date == start_date`` and represents the index
+    membership at the *opening* of the backtest.  Each subsequent entry records
+    a membership change event within ``(start_date, end_date]``.
+
+    Query membership on any date with ``pit_members_on(schedule, date)``.
+
+    Parameters
+    ----------
+    index       : ``"nq100"`` or ``"sp500"``
+    start_date  : ISO date string
+    end_date    : ISO date string
+    config      : Optional backtester config (see ``tickers_union_for_period``).
+
+    Returns
+    -------
+    list[tuple[str, frozenset]]
+        Sorted ``[(date_str, frozenset_of_tickers), ...]``.
+    """
+    idx = _canonical_index(index)
+    sy = int(start_date[:4])
+    ey = int(end_date[:4])
+
+    # --- Step 1: derive initial membership at exactly start_date ---
+    members: set[str] = set()
+    try:
+        path = _find_year_yaml(idx, sy, config)
+        data = _load_year_yaml(path)
+        members = {normalise_pit_ticker(t) for t in (data.get("tickers_on_Jan_1") or [])}
+        for change_date in sorted(str(d) for d in (data.get("changes") or {}).keys()):
+            if change_date > start_date:
+                break
+            entry = (data.get("changes") or {}).get(change_date) or {}
+            members -= {normalise_pit_ticker(t) for t in (entry.get("difference") or [])}
+            members |= {normalise_pit_ticker(t) for t in (entry.get("union") or [])}
+    except FileNotFoundError:
+        pass
+
+    schedule: list[tuple[str, frozenset]] = [(start_date, frozenset(members))]
+
+    # --- Step 2: record every change event strictly after start_date ---
+    for year in range(sy, ey + 1):
+        try:
+            path = _find_year_yaml(idx, year, config)
+            data = _load_year_yaml(path)
+        except FileNotFoundError:
+            continue
+        for change_date in sorted(str(d) for d in (data.get("changes") or {}).keys()):
+            if change_date <= start_date or change_date > end_date:
+                continue
+            entry = (data.get("changes") or {}).get(change_date) or {}
+            current = set(schedule[-1][1])
+            current -= {normalise_pit_ticker(t) for t in (entry.get("difference") or [])}
+            current |= {normalise_pit_ticker(t) for t in (entry.get("union") or [])}
+            schedule.append((change_date, frozenset(current)))
+
+    return schedule
+
+
+def pit_members_on(schedule: list[tuple[str, frozenset]], date: str) -> frozenset:
+    """Return the PIT member frozenset on *date* using a prebuilt schedule.
+
+    Uses binary search — O(log k) where k is the number of change events.
+
+    Parameters
+    ----------
+    schedule : output of ``build_membership_schedule``
+    date     : ISO date string (``"2010-05-15"``)
+
+    Returns
+    -------
+    frozenset[str]
+        The set of index members on that date.  Empty frozenset if *date* is
+        before the first schedule entry.
+    """
+    dates = [s[0] for s in schedule]
+    idx = bisect.bisect_right(dates, date) - 1
+    if idx < 0:
+        return frozenset()
+    return schedule[idx][1]

--- a/main.py
+++ b/main.py
@@ -335,6 +335,8 @@ def main():
                 _symbol_counts[_pname] = "?"
         elif isinstance(_pvalue, str) and _pvalue.startswith("norgate:"):
             _symbol_counts[_pname] = "? (Norgate)"
+        elif isinstance(_pvalue, str) and _pvalue.startswith("pit:"):
+            _symbol_counts[_pname] = f"? ({_pvalue} - resolved at runtime)"
         else:
             _symbol_counts[_pname] = "?"
 
@@ -494,6 +496,16 @@ def main():
              file_path = os.path.join("tickers_to_scan", value)
              with open(file_path, 'rb') as f:
                  symbols = orjson.loads(f.read())
+        elif isinstance(value, str) and value.startswith("pit:"):
+            from helpers.point_in_time import resolve_pit_portfolio
+            try:
+                symbols = resolve_pit_portfolio(value, CONFIG) or []
+            except Exception as e:
+                logger.error(f"  -> ERROR resolving PIT portfolio '{value}' for '{portfolio_name}': {e}")
+                continue
+            logger.info(
+                f"  -> {value} universe as of {CONFIG['start_date']}: {len(symbols)} tickers"
+            )
         
         if not symbols:
             logger.warning(f"No symbols found for '{portfolio_name}'. Skipping.")

--- a/main.py
+++ b/main.py
@@ -42,17 +42,19 @@ def _pick_reference_df(comparison_dfs: dict) -> pd.DataFrame:
 # --------------------------------------------------------------------
 # --- WORKER INITIALIZER FOR MULTIPROCESSING ---
 # --------------------------------------------------------------------
-def init_worker(comparison_dfs_dict, benchmark_returns_dict, dependency_map_dict, portfolio_data_for_worker):
+def init_worker(comparison_dfs_dict, benchmark_returns_dict, dependency_map_dict, portfolio_data_for_worker, pit_member_masks_dict=None):
     """
     Initializer for the multiprocessing pool.
     Makes comparison ticker DataFrames, benchmark returns, dependency symbol map,
-    and the current portfolio's data globally available to each worker process.
+    the current portfolio's data, and optional PIT membership masks globally
+    available to each worker process.
     """
-    global comparison_dfs_global, benchmark_returns_global, dependency_map_global, portfolio_data_global
+    global comparison_dfs_global, benchmark_returns_global, dependency_map_global, portfolio_data_global, pit_member_masks_global
     comparison_dfs_global = comparison_dfs_dict
     benchmark_returns_global = benchmark_returns_dict
     dependency_map_global = dependency_map_dict
     portfolio_data_global = portfolio_data_for_worker
+    pit_member_masks_global = pit_member_masks_dict
 
 # --------------------------------------------------------------------
 
@@ -109,6 +111,26 @@ def run_single_simulation(args):
 
         # The simulator now handles stop-loss logic internally.
         final_signals = {symbol: df['Signal'] for symbol, df in base_signals_with_dfs.items()}
+
+        # --- PIT SIGNAL GATING ---
+        # When the portfolio was built from a ``pit:`` universe, apply two filters:
+        # 1. Block long entries (Signal==1) on dates when the symbol is not an index member.
+        # 2. Inject exit signals (Signal==-1) on the first trading day after a symbol
+        #    is removed from the index, so open positions are closed promptly.
+        # This runs per-simulation but mask computation is O(1) per date (precomputed).
+        if pit_member_masks_global is not None:
+            for symbol, sig in list(final_signals.items()):
+                mask = pit_member_masks_global.get(symbol)
+                if mask is None:
+                    continue
+                aligned = mask.reindex(sig.index, fill_value=False)
+                new_sig = sig.copy()
+                new_sig.loc[(sig == 1) & ~aligned] = 0
+                was_member = aligned.shift(1, fill_value=False)
+                removal_days = ~aligned & was_member
+                new_sig.loc[removal_days] = -1
+                final_signals[symbol] = new_sig
+        # --- END PIT SIGNAL GATING ---
 
         # Call the simulation, passing the stop_config and using the global dataframes.
         result = run_portfolio_simulation(
@@ -474,7 +496,8 @@ def main():
     # Loop through each portfolio sequentially
     for portfolio_name, value in _portfolios.items():
         logger.info(f"--> Preparing and running portfolio: {portfolio_name}")
-        
+        _current_pit_schedule = None  # reset each portfolio; set only for pit: portfolios
+
         # --- Data fetching for the current portfolio (no changes) ---
         # (Your existing code to get symbols and build `portfolio_data` is perfect)
         symbols = []
@@ -497,14 +520,17 @@ def main():
              with open(file_path, 'rb') as f:
                  symbols = orjson.loads(f.read())
         elif isinstance(value, str) and value.startswith("pit:"):
-            from helpers.point_in_time import resolve_pit_portfolio
+            from helpers.point_in_time import tickers_union_for_period as _pit_union, build_membership_schedule as _pit_schedule_build
+            _pit_index_name = value.split(":", 1)[1]
             try:
-                symbols = resolve_pit_portfolio(value, CONFIG) or []
+                symbols = _pit_union(_pit_index_name, CONFIG["start_date"], CONFIG["end_date"], CONFIG)
+                _current_pit_schedule = _pit_schedule_build(_pit_index_name, CONFIG["start_date"], CONFIG["end_date"], CONFIG)
             except Exception as e:
                 logger.error(f"  -> ERROR resolving PIT portfolio '{value}' for '{portfolio_name}': {e}")
                 continue
             logger.info(
-                f"  -> {value} universe as of {CONFIG['start_date']}: {len(symbols)} tickers"
+                f"  -> {value} full historical union ({CONFIG['start_date']} to {CONFIG['end_date']}): "
+                f"{len(symbols)} tickers (PIT membership enforced during simulation)"
             )
         
         if not symbols:
@@ -575,6 +601,28 @@ def main():
             logger.warning(f"Could not fetch data for any symbols in '{portfolio_name}'. Skipping.")
             continue
 
+        # --- PIT MEMBERSHIP MASKS (precomputed once per portfolio) ---
+        # For pit: portfolios, build a boolean Series per symbol marking which
+        # trading dates the symbol was an index member.  Workers apply this mask
+        # to gate entry signals and inject exit signals — zero per-simulation
+        # overhead beyond a vectorised lookup.
+        if _current_pit_schedule is not None:
+            from helpers.point_in_time import pit_members_on as _pit_members_on
+            _pit_member_masks: dict[str, object] = {}
+            for _sym, _df in portfolio_data.items():
+                _dates = _df.index
+                _date_strs = [str(d)[:10] for d in _dates]
+                _pit_member_masks[_sym] = pd.Series(
+                    [_sym in _pit_members_on(_current_pit_schedule, d) for d in _date_strs],
+                    index=_dates,
+                    dtype=bool,
+                )
+            _n_with_history = sum(m.any() for m in _pit_member_masks.values())
+            logger.info(f"  -> PIT masks built: {_n_with_history}/{len(_pit_member_masks)} symbols have at least one membership day")
+        else:
+            _pit_member_masks = None
+        # --- END PIT MEMBERSHIP MASKS ---
+
         # --- Generate tasks for THIS portfolio, WITHOUT the large `portfolio_data` ---
         tasks_for_this_portfolio = []
         for strat_name, strategy_config in get_active_strategies().items():
@@ -606,8 +654,8 @@ def main():
         logger.info("=" * 15 + f" RUNNING SIMULATIONS FOR '{portfolio_name}' " + "=" * 15)
         logger.info(f"Found {len(tasks_for_this_portfolio)} tasks. Using up to {cpu_count()} CPU cores.")
         
-        # Pass comparison data and portfolio data during initialization, not with each task
-        init_args = (comparison_dfs, benchmark_returns, comparison_config["dependencies"], portfolio_data)
+        # Pass comparison data, portfolio data, and PIT masks during initialization
+        init_args = (comparison_dfs, benchmark_returns, comparison_config["dependencies"], portfolio_data, _pit_member_masks)
 
         with Pool(processes=cpu_count(), initializer=init_worker, initargs=init_args) as p:
             import time as _time

--- a/main.py
+++ b/main.py
@@ -39,6 +39,14 @@ def _pick_reference_df(comparison_dfs: dict) -> pd.DataFrame:
     return next(iter(comparison_dfs.values()))
 
 
+# Module-level defaults so workers can reference these globals safely even in
+# test contexts where init_worker was never called.
+comparison_dfs_global = None
+benchmark_returns_global = None
+dependency_map_global = None
+portfolio_data_global = None
+pit_member_masks_global = None
+
 # --------------------------------------------------------------------
 # --- WORKER INITIALIZER FOR MULTIPROCESSING ---
 # --------------------------------------------------------------------
@@ -64,7 +72,7 @@ def run_single_simulation(args):
     This version now uses globally initialized dataframes AND portfolio_data.
     """
     # Access ALL globally initialized data
-    global comparison_dfs_global, benchmark_returns_global, dependency_map_global, portfolio_data_global
+    global comparison_dfs_global, benchmark_returns_global, dependency_map_global, portfolio_data_global, pit_member_masks_global
 
     # 1. Unpack the arguments. `portfolio_data` has been REMOVED from the tuple.
     portfolio_name, name, logic_func, dependencies, stop_config, \

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ tqdm==4.67.1
 boto3==1.40.2          # used for S3 report uploads only, not auth
 requests==2.32.3
 python-dotenv==1.1.1
+PyYAML==6.0.2
 pandas-ta==0.3.14b0
 orjson==3.11.1
 pyarrow==21.0.0

--- a/services/parquet_service.py
+++ b/services/parquet_service.py
@@ -54,6 +54,9 @@ def _find_parquet(symbol: str, parquet_dir: str) -> str | None:
     """
     Find the Parquet file for *symbol* with case-insensitive lookup.
     Returns the full file path, or None if not found.
+    Also checks for Norgate-style date-suffixed files (e.g. ALTR-201512.parquet)
+    used for delisted/acquired tickers; returns the sentinel "_multi_" string
+    when multiple date-suffix files exist (caller must use _find_parquet_multi).
     """
     if not os.path.isdir(parquet_dir):
         logger.warning(f"Parquet data directory does not exist: {parquet_dir}")
@@ -73,6 +76,18 @@ def _find_parquet(symbol: str, parquet_dir: str) -> str | None:
     for fname in os.listdir(parquet_dir):
         if fname.upper() == target:
             return os.path.join(parquet_dir, fname)
+
+    # Fallback: Norgate date-suffixed files e.g. ALTR-201512.parquet
+    prefix = safe.upper() + "-"
+    dated = sorted(
+        fname for fname in os.listdir(parquet_dir)
+        if fname.upper().startswith(prefix) and fname.upper().endswith(".PARQUET")
+    )
+    if len(dated) == 1:
+        return os.path.join(parquet_dir, dated[0])
+    if len(dated) > 1:
+        # Signal to caller that multiple period files exist
+        return "_multi_|" + parquet_dir + "|" + safe
 
     return None
 
@@ -161,11 +176,30 @@ def get_price_data(symbol: str, start_date: str, end_date: str, config: dict):
         )
         return None
 
-    try:
-        df = pd.read_parquet(filepath)
-    except Exception as e:
-        logger.error(f"Failed to read parquet file '{filepath}': {e}")
-        return None
+    # Handle multiple date-suffix period files (Norgate delisted format)
+    if filepath.startswith("_multi_|"):
+        _, fdir, safe = filepath.split("|", 2)
+        prefix = safe.upper() + "-"
+        parts = sorted(
+            f for f in os.listdir(fdir)
+            if f.upper().startswith(prefix) and f.upper().endswith(".PARQUET")
+        )
+        frames = []
+        for part in parts:
+            try:
+                frames.append(pd.read_parquet(os.path.join(fdir, part)))
+            except Exception as e:
+                logger.warning(f"Could not read '{part}': {e}")
+        if not frames:
+            return None
+        df = pd.concat(frames).sort_index()
+        df = df[~df.index.duplicated(keep="first")]
+    else:
+        try:
+            df = pd.read_parquet(filepath)
+        except Exception as e:
+            logger.error(f"Failed to read parquet file '{filepath}': {e}")
+            return None
 
     logger.debug(f"Loaded {len(df)} rows from {filepath}")
 

--- a/tests/test_point_in_time.py
+++ b/tests/test_point_in_time.py
@@ -39,7 +39,8 @@ changes:
 
     jan_members = tickers_as_of("sp500", "2020-01-15", config)
     assert "BKNG" in jan_members
-    assert "GOOGL" in jan_members
+    assert "GOOG" in jan_members   # GOOG is NOT remapped — both share classes stay distinct
+    assert "GOOGL" not in jan_members
     assert "BRK-B" in jan_members
     assert "PCLN" not in jan_members
 

--- a/tests/test_point_in_time.py
+++ b/tests/test_point_in_time.py
@@ -2,7 +2,13 @@ from pathlib import Path
 
 import pytest
 
-from helpers.point_in_time import resolve_pit_portfolio, tickers_as_of
+from helpers.point_in_time import (
+    resolve_pit_portfolio,
+    tickers_as_of,
+    tickers_union_for_period,
+    build_membership_schedule,
+    pit_members_on,
+)
 
 
 def _write_yaml(path: Path, text: str) -> None:
@@ -95,3 +101,191 @@ changes: {}
 def test_missing_pit_yaml_has_friendly_error(tmp_path):
     with pytest.raises(FileNotFoundError, match="No PIT YAML found"):
         tickers_as_of("sp500", "1900-01-01", {"sp500_pit_path": str(tmp_path)})
+
+
+# ---------------------------------------------------------------------------
+# tickers_union_for_period
+# ---------------------------------------------------------------------------
+
+_MULTI_YEAR_NQ = """
+year: {year}
+tickers_on_Jan_1:
+  - AAPL
+  - MSFT
+changes:
+  '{year}-06-01':
+    difference:
+      - MSFT
+    union:
+      - NVDA_{year}
+"""
+
+
+def _nq_repo_two_years(tmp_path: Path) -> Path:
+    root = tmp_path / "nq_repo"
+    for yr in (2020, 2021):
+        _write_yaml(
+            root / "src" / "nasdaq_100_ticker_history" / f"n100-ticker-changes-{yr}.yaml",
+            _MULTI_YEAR_NQ.format(year=yr),
+        )
+    return root
+
+
+def test_union_includes_all_historical_tickers(tmp_path):
+    root = _nq_repo_two_years(tmp_path)
+    config = {"nq100_pit_path": str(root)}
+    union = tickers_union_for_period("nq100", "2020-01-01", "2021-12-31", config)
+    assert "AAPL" in union
+    assert "MSFT" in union       # removed during 2020 but WAS in the index
+    assert "NVDA_2020" in union  # added during 2020
+    assert "NVDA_2021" in union  # added during 2021
+    assert union == sorted(set(union))  # result is sorted
+
+
+def test_union_skips_missing_years_gracefully(tmp_path):
+    root = _nq_repo_two_years(tmp_path)
+    config = {"nq100_pit_path": str(root)}
+    # 2022 YAML does not exist — should not raise, just skip that year
+    union = tickers_union_for_period("nq100", "2020-01-01", "2022-12-31", config)
+    assert "AAPL" in union  # still returns what's available
+
+
+def test_union_single_year(tmp_path):
+    root = tmp_path / "nq_repo"
+    _write_yaml(
+        root / "src" / "nasdaq_100_ticker_history" / "n100-ticker-changes-2019.yaml",
+        """
+year: 2019
+tickers_on_Jan_1:
+  - AAPL
+  - AMZN
+changes:
+  '2019-09-15':
+    difference:
+      - AMZN
+    union:
+      - TSLA
+""",
+    )
+    config = {"nq100_pit_path": str(root)}
+    union = tickers_union_for_period("nq100", "2019-01-01", "2019-12-31", config)
+    assert set(union) == {"AAPL", "AMZN", "TSLA"}
+
+
+# ---------------------------------------------------------------------------
+# build_membership_schedule and pit_members_on
+# ---------------------------------------------------------------------------
+
+_NQ_SCHEDULE_YAML = """
+year: 2022
+tickers_on_Jan_1:
+  - AAPL
+  - MSFT
+  - GOOG
+changes:
+  '2022-03-01':
+    difference:
+      - MSFT
+    union:
+      - NVDA
+  '2022-07-15':
+    difference:
+      - GOOG
+    union:
+      - META
+"""
+
+
+def _schedule_config(tmp_path: Path) -> dict:
+    root = tmp_path / "nq_repo"
+    _write_yaml(
+        root / "src" / "nasdaq_100_ticker_history" / "n100-ticker-changes-2022.yaml",
+        _NQ_SCHEDULE_YAML,
+    )
+    return {"nq100_pit_path": str(root)}
+
+
+def test_schedule_initial_state(tmp_path):
+    config = _schedule_config(tmp_path)
+    schedule = build_membership_schedule("nq100", "2022-01-01", "2022-12-31", config)
+    initial = pit_members_on(schedule, "2022-01-15")
+    assert initial == frozenset({"AAPL", "MSFT", "GOOG"})
+
+
+def test_schedule_after_first_change(tmp_path):
+    config = _schedule_config(tmp_path)
+    schedule = build_membership_schedule("nq100", "2022-01-01", "2022-12-31", config)
+    members = pit_members_on(schedule, "2022-03-01")
+    assert "NVDA" in members
+    assert "MSFT" not in members
+    assert "AAPL" in members
+
+
+def test_schedule_after_second_change(tmp_path):
+    config = _schedule_config(tmp_path)
+    schedule = build_membership_schedule("nq100", "2022-01-01", "2022-12-31", config)
+    members = pit_members_on(schedule, "2022-08-01")
+    assert "META" in members
+    assert "GOOG" not in members
+    assert "NVDA" in members
+
+
+def test_schedule_before_first_entry_returns_initial(tmp_path):
+    config = _schedule_config(tmp_path)
+    schedule = build_membership_schedule("nq100", "2022-01-01", "2022-12-31", config)
+    # Query exactly at start_date
+    assert pit_members_on(schedule, "2022-01-01") == frozenset({"AAPL", "MSFT", "GOOG"})
+
+
+def test_schedule_start_date_mid_year(tmp_path):
+    """When start_date is mid-year, initial state reflects changes applied up to that date."""
+    config = _schedule_config(tmp_path)
+    schedule = build_membership_schedule("nq100", "2022-04-01", "2022-12-31", config)
+    # 2022-03-01 change should be baked into the initial state
+    initial = pit_members_on(schedule, "2022-04-01")
+    assert "NVDA" in initial
+    assert "MSFT" not in initial
+    assert "GOOG" in initial  # second change not yet applied
+
+
+def test_pit_members_on_before_schedule_returns_empty(tmp_path):
+    config = _schedule_config(tmp_path)
+    schedule = build_membership_schedule("nq100", "2022-06-01", "2022-12-31", config)
+    # Query before the schedule starts
+    result = pit_members_on(schedule, "2021-01-01")
+    assert result == frozenset()
+
+
+def test_schedule_spans_multiple_years(tmp_path):
+    root = tmp_path / "nq_repo"
+    for yr, content in [
+        (2021, """
+year: 2021
+tickers_on_Jan_1:
+  - AAPL
+changes:
+  '2021-06-01':
+    difference: []
+    union:
+      - AMZN
+"""),
+        (2022, """
+year: 2022
+tickers_on_Jan_1:
+  - AAPL
+  - AMZN
+changes:
+  '2022-03-01':
+    union:
+      - TSLA
+"""),
+    ]:
+        _write_yaml(
+            root / "src" / "nasdaq_100_ticker_history" / f"n100-ticker-changes-{yr}.yaml",
+            content,
+        )
+    config = {"nq100_pit_path": str(root)}
+    schedule = build_membership_schedule("nq100", "2021-01-01", "2022-12-31", config)
+    assert "AMZN" in pit_members_on(schedule, "2021-07-01")
+    assert "TSLA" in pit_members_on(schedule, "2022-04-01")
+    assert "TSLA" not in pit_members_on(schedule, "2022-02-01")

--- a/tests/test_point_in_time.py
+++ b/tests/test_point_in_time.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+import pytest
+
+from helpers.point_in_time import resolve_pit_portfolio, tickers_as_of
+
+
+def _write_yaml(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_sp500_tickers_as_of_start_date_with_normalisation(tmp_path):
+    root = tmp_path / "sp500_repo"
+    _write_yaml(
+        root / "src" / "sp500_ticker_history" / "sp500-ticker-changes-2020.yaml",
+        """
+year: 2020
+tickers_on_Jan_1:
+  - AAA
+  - GOOG
+  - PCLN
+  - BRK.B
+changes:
+  '2020-02-01':
+    difference:
+      - AAA
+    union:
+      - CCC
+  '2020-07-01':
+    difference:
+      - CCC
+    union:
+      - DDD
+""",
+    )
+
+    config = {"sp500_pit_path": str(root)}
+
+    jan_members = tickers_as_of("sp500", "2020-01-15", config)
+    assert "BKNG" in jan_members
+    assert "GOOGL" in jan_members
+    assert "BRK-B" in jan_members
+    assert "PCLN" not in jan_members
+
+    june_members = tickers_as_of("s&p500", "2020-06-30", config)
+    assert "AAA" not in june_members
+    assert "CCC" in june_members
+    assert "DDD" not in june_members
+
+
+def test_nq100_tickers_as_of_uses_n100_yaml_name(tmp_path):
+    root = tmp_path / "nq_repo"
+    _write_yaml(
+        root / "src" / "nasdaq_100_ticker_history" / "n100-ticker-changes-2021.yaml",
+        """
+year: 2021
+tickers_on_Jan_1:
+  - AAPL
+  - MSFT
+changes:
+  '2021-03-10':
+    difference:
+      - MSFT
+    union:
+      - NVDA
+""",
+    )
+
+    config = {"nq100_pit_path": str(root)}
+
+    assert tickers_as_of("nq100", "2021-03-09", config) == ["AAPL", "MSFT"]
+    assert tickers_as_of("nasdaq-100", "2021-03-10", config) == ["AAPL", "NVDA"]
+
+
+def test_resolve_pit_portfolio_reads_config_start_date(tmp_path):
+    root = tmp_path / "sp500_repo"
+    _write_yaml(
+        root / "src" / "sp500_ticker_history" / "sp500-ticker-changes-2022.yaml",
+        """
+year: 2022
+tickers_on_Jan_1:
+  - AAPL
+changes: {}
+""",
+    )
+
+    config = {"start_date": "2022-04-01", "sp500_pit_path": str(root)}
+
+    assert resolve_pit_portfolio("pit:sp500", config) == ["AAPL"]
+    assert resolve_pit_portfolio("sp500_pit", config) is None
+
+
+def test_missing_pit_yaml_has_friendly_error(tmp_path):
+    with pytest.raises(FileNotFoundError, match="No PIT YAML found"):
+        tickers_as_of("sp500", "1900-01-01", {"sp500_pit_path": str(tmp_path)})


### PR DESCRIPTION
## What this PR does

Adds point-in-time index universe support for portfolio definitions like `"pit:nq100"` and `"pit:sp500"`, so S&P 500 / Nasdaq 100 backtests can resolve membership as of the configured `start_date` instead of relying only on static survivor JSON files.

## Tasks addressed

Fixes zachisit/july-backtester#165

## Changes made

| File | Change |
|------|--------|
| `helpers/point_in_time.py` | Added PIT YAML loader, index aliases, ticker normalization, and `tickers_as_of()` / `resolve_pit_portfolio()` helpers. |
| `main.py` | Added support for resolving portfolio values starting with `pit:` and logging the resolved universe count. |
| `tests/test_point_in_time.py` | Added focused tests for S&P 500 PIT, Nasdaq 100 PIT, ticker normalization, resolver behavior, and friendly missing-file errors. |
| `README.md` | Documented user-facing `pit:nq100` and `pit:sp500` portfolio syntax. |
| `CLAUDE.md` | Documented the new helper and PIT portfolio config examples. |

## Tests

```text
rtk pytest tests/ --ignore=tests/test_report_batch.py -q
Codex result:

Command timed out after 604486 ms.
Focused verification run:

rtk pytest tests\test_point_in_time.py -q
Pytest: 4 passed
Compile check:

rtk python -m py_compile helpers\point_in_time.py main.py
passed
Checklist
[  ] Full test suite passes locally (rtk pytest tests/ --ignore=tests/test_report_batch.py -q)
[x] No API keys, .env files, data_cache/, or output/ committed
[x] CLAUDE.md updated if new helpers, config keys, or architecture changes were made
[x] README.md updated if user-facing config or behaviour changed
[x] New strategies have a docstring explaining signal logic and params
[x] If a new config key was added, it has a default that preserves existing behaviour

⚠️ Bonus work policy
This PR only addresses the point-in-time universe support requested in issue #165.