### PR TITLE
fix(csv_service): dollar/comma stripping broken on pandas 3.0+ StringDtype

### DIFF
--- a/services/csv_service.py
+++ b/services/csv_service.py
@@ -224,8 +224,10 @@ def get_price_data(symbol: str, start_date: str, end_date: str, config: dict):
     # --- Keep only canonical columns, coerce to numeric ---
     df = df[_CANONICAL_COLS].copy()
     for col in _CANONICAL_COLS:
-        # Strip currency formatting ($1,234.56 → 1234.56) before numeric coercion
-        if df[col].dtype == object:
+        # Strip currency formatting ($1,234.56 → 1234.56) before numeric coercion.
+        # Use is_numeric_dtype rather than dtype == object so this works on both
+        # pandas 2.x (object dtype) and pandas 3.x (StringDtype).
+        if not pd.api.types.is_numeric_dtype(df[col]):
             df[col] = df[col].astype(str).str.replace(r"[$,]", "", regex=True).str.strip()
         df[col] = pd.to_numeric(df[col], errors="coerce")
 


### PR DESCRIPTION
## Summary

Fixes 4 failing tests in `TestNasdaqFormat`. Nasdaq-format CSVs with `$`-prefixed prices produce all-NaN columns on pandas 3.0+.

Closes #169

## Root cause

`pd.read_csv` returns string columns as `StringDtype` in pandas 3.0+ (new default for `future.infer_string`). The old guard `if df[col].dtype == object` evaluates to `False`, skipping the `$`/`,` stripping, and `pd.to_numeric(errors="coerce")` silently converts `$264.72` to `NaN`.

## Change

`services/csv_service.py` — one-line guard change:

```python
# Before (breaks on pandas 3.0+)
if df[col].dtype == object:

# After (works on pandas 2.x and 3.x)
if not pd.api.types.is_numeric_dtype(df[col]):
```

## Tests

| | Before | After |
|---|---|---|
| Passing | 1,205 | 1,209 |
| Failing | 4 | 0 |