### PR TITLE
feat(scripts): Polygon -> Parquet daily updater + weekly IPO scan (#191)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ __pycache__/
 .vscode/
 .idea/
 
+# Daily cron logs (scripts/polygon_daily_update.sh)
+logs/
+
 # Environment variables file
 .env
 *.env

--- a/scripts/polygon_daily_update.py
+++ b/scripts/polygon_daily_update.py
@@ -1,0 +1,353 @@
+"""
+polygon_daily_update.py — daily Polygon → Parquet updater (Issue #191).
+
+Keeps the ``parquet_data/`` submodule current after the Norgate freeze at
+2026-04-22. For every symbol that already has a Parquet file it fetches the new
+daily bars from Polygon and appends them, writing files in exactly the format
+the backtester's ``data_provider: "parquet"`` path expects:
+
+    Index  : DatetimeIndex, UTC-aware, name='Datetime', midnight-normalized
+    Columns: ['Open', 'High', 'Low', 'Close', 'Volume']
+
+Symbol universe (three kinds, by filename prefix):
+    (none)  AAPL.parquet   → equity. Fetched via the grouped endpoint
+                             (one call per date returns every ticker) — cheap.
+    $       $VIX.parquet    → index. Mapped to Polygon's ``I:VIX`` via
+                             helpers.ticker_normalizer.normalize_ticker and
+                             fetched per-ticker (indices are not in grouped/stocks).
+    #       #AMEXAD.parquet → Norgate-only market-breadth indicator. Not on
+                             Polygon — skipped and frozen at 2026-04-22.
+
+Adjustment seam (see #191): Polygon ``adjusted=true`` is split-adjusted only
+(no dividend reinvestment), whereas Norgate was total-return. Bars at/after the
+seam therefore diverge for dividend payers. This is accepted per the issue
+decision — split-adjusted only, no dividend pull.
+
+Usage:
+    python scripts/polygon_daily_update.py                  # update to last trading day
+    python scripts/polygon_daily_update.py --start 2026-04-23   # backfill override
+    python scripts/polygon_daily_update.py --dry-run        # plan only, no writes
+    python scripts/polygon_daily_update.py --limit 50       # process first 50 files (testing)
+    python scripts/polygon_daily_update.py --only AAPL,MSFT,\\$VIX   # subset
+"""
+
+import os
+import sys
+import time
+import logging
+import argparse
+from datetime import datetime, timedelta
+
+import pandas as pd
+import requests
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, PROJECT_ROOT)
+
+from helpers.ticker_normalizer import normalize_ticker  # noqa: E402
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv(os.path.join(PROJECT_ROOT, ".env"))
+except ImportError:
+    pass
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger("polygon_daily_update")
+
+API_BASE = "https://api.polygon.io"
+DEFAULT_DATA_DIR = os.path.join("parquet_data", "data")
+SEAM_DATE = "2026-04-23"          # first day Norgate did NOT cover (last Norgate bar = 2026-04-22)
+CANONICAL_COLS = ["Open", "High", "Low", "Close", "Volume"]
+_RATE_LIMIT_SLEEP = 0.0           # seconds between per-ticker index calls; bumped on HTTP 429
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Symbol classification
+# ──────────────────────────────────────────────────────────────────────────────
+def classify_symbol(filename: str) -> tuple[str, str]:
+    """Map a parquet filename to (kind, base_symbol).
+
+    kind is one of "equity", "index", "breadth". base_symbol keeps the original
+    Norgate prefix ($ for indices) so normalize_ticker can map it to Polygon.
+    """
+    base = filename[:-len(".parquet")] if filename.lower().endswith(".parquet") else filename
+    if base.startswith("#"):
+        return "breadth", base
+    if base.startswith("$"):
+        return "index", base
+    return "equity", base
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Polygon HTTP
+# ──────────────────────────────────────────────────────────────────────────────
+def get_api_key() -> str:
+    key = os.environ.get("POLYGON_API_KEY")
+    if not key:
+        logger.error("POLYGON_API_KEY not set (env or .env). Cannot fetch from Polygon.")
+        sys.exit(1)
+    return key
+
+
+def polygon_get(session: requests.Session, api_key: str, path: str, params: dict | None = None) -> dict:
+    """GET a Polygon endpoint and return parsed JSON. Returns {} on HTTP error."""
+    p = {"apiKey": api_key}
+    if params:
+        p.update(params)
+    try:
+        resp = session.get(API_BASE + path, params=p, timeout=30)
+        if resp.status_code == 429:
+            logger.warning("Polygon rate limit (429) on %s — backing off 5s.", path)
+            time.sleep(5)
+            resp = session.get(API_BASE + path, params=p, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.exceptions.RequestException as e:
+        logger.warning("Polygon HTTP error on %s: %s", path, e)
+        return {}
+
+
+def fetch_grouped_day(session, api_key, date_str: str, adjusted: bool) -> dict[str, dict]:
+    """One grouped call → {TICKER_UPPER: {o,h,l,c,v}} for every equity on date_str.
+
+    Empty dict on a market holiday / weekend (resultsCount == 0).
+    """
+    resp = polygon_get(
+        session, api_key,
+        f"/v2/aggs/grouped/locale/us/market/stocks/{date_str}",
+        {"adjusted": "true" if adjusted else "false"},
+    )
+    out: dict[str, dict] = {}
+    for bar in resp.get("results", []) or []:
+        t = bar.get("T")
+        if not t:
+            continue
+        out[t.upper()] = {
+            "o": bar.get("o"), "h": bar.get("h"),
+            "l": bar.get("l"), "c": bar.get("c"), "v": bar.get("v", 0),
+        }
+    return out
+
+
+def fetch_ticker_range(session, api_key, polygon_symbol: str, start: str, end: str, adjusted: bool) -> list[dict]:
+    """Per-ticker aggregates over [start, end] — used for index ($) symbols."""
+    resp = polygon_get(
+        session, api_key,
+        f"/v2/aggs/ticker/{polygon_symbol}/range/1/day/{start}/{end}",
+        {"adjusted": "true" if adjusted else "false", "sort": "asc", "limit": 50000},
+    )
+    return resp.get("results", []) or []
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Parquet I/O
+# ──────────────────────────────────────────────────────────────────────────────
+def read_last_date(path: str) -> pd.Timestamp | None:
+    """Return the last (max) DatetimeIndex value in a parquet file, or None."""
+    try:
+        df = pd.read_parquet(path)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Could not read %s: %s", path, e)
+        return None
+    if df.empty:
+        return None
+    idx = pd.to_datetime(df.index, utc=True)
+    return idx.max()
+
+
+def bars_to_df(rows: list[dict]) -> pd.DataFrame:
+    """Convert Polygon agg rows (with 't' ms timestamps) to the canonical frame."""
+    if not rows:
+        return pd.DataFrame(columns=CANONICAL_COLS)
+    df = pd.DataFrame(rows)
+    df["Datetime"] = pd.to_datetime(df["t"], unit="ms", utc=True).dt.normalize()
+    df = df.set_index("Datetime")
+    df = df.rename(columns={"o": "Open", "h": "High", "l": "Low", "c": "Close", "v": "Volume"})
+    present = [c for c in CANONICAL_COLS if c in df.columns]
+    return df[present]
+
+
+def grouped_rows_to_df(day_rows: list[tuple[str, dict]]) -> pd.DataFrame:
+    """Build a canonical frame from [(date_str, {o,h,l,c,v}), ...] grouped hits."""
+    if not day_rows:
+        return pd.DataFrame(columns=CANONICAL_COLS)
+    recs = []
+    for date_str, bar in day_rows:
+        recs.append({
+            "Datetime": pd.Timestamp(date_str, tz="UTC").normalize(),
+            "Open": bar.get("o"), "High": bar.get("h"), "Low": bar.get("l"),
+            "Close": bar.get("c"), "Volume": bar.get("v", 0),
+        })
+    df = pd.DataFrame(recs).set_index("Datetime")
+    return df[[c for c in CANONICAL_COLS if c in df.columns]]
+
+
+def append_and_write(path: str, new_df: pd.DataFrame, dry_run: bool) -> int:
+    """Append new_df to the existing parquet, dedup on index (keep last), sort.
+
+    Returns the number of genuinely new rows written (after dedup).
+    """
+    if new_df is None or new_df.empty:
+        return 0
+    new_df = new_df.copy()
+    new_df.index = pd.to_datetime(new_df.index, utc=True)
+
+    if os.path.exists(path):
+        try:
+            existing = pd.read_parquet(path)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Could not read existing %s for append: %s", path, e)
+            existing = pd.DataFrame(columns=CANONICAL_COLS)
+        existing.index = pd.to_datetime(existing.index, utc=True)
+        before = len(existing)
+        combined = pd.concat([existing, new_df])
+    else:
+        before = 0
+        combined = new_df
+
+    combined = combined[~combined.index.duplicated(keep="last")].sort_index()
+    combined.index.name = "Datetime"
+    added = len(combined) - before
+    if added <= 0:
+        return 0
+    if not dry_run:
+        combined.to_parquet(path)
+    return added
+
+
+def last_trading_day(session, api_key, before: str | None = None) -> str:
+    """Most recent trading day (YYYY-MM-DD) per Polygon SPY data."""
+    d = datetime.now() if before is None else datetime.strptime(before, "%Y-%m-%d")
+    for _ in range(10):
+        d -= timedelta(days=1)
+        ds = d.strftime("%Y-%m-%d")
+        resp = polygon_get(session, api_key, f"/v2/aggs/ticker/SPY/range/1/day/{ds}/{ds}")
+        if resp.get("resultsCount", 0) > 0:
+            return ds
+    raise RuntimeError("Could not determine last trading day from Polygon.")
+
+
+def _business_days(start: str, end: str) -> list[str]:
+    return [d.strftime("%Y-%m-%d") for d in pd.bdate_range(start=start, end=end)]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Main
+# ──────────────────────────────────────────────────────────────────────────────
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Daily Polygon -> Parquet updater (#191)")
+    ap.add_argument("--start", help="Backfill start date YYYY-MM-DD (override per-file last date)")
+    ap.add_argument("--end", help="End date YYYY-MM-DD (default: last trading day)")
+    ap.add_argument("--data-dir", default=DEFAULT_DATA_DIR, help=f"Parquet dir (default {DEFAULT_DATA_DIR})")
+    ap.add_argument("--dry-run", action="store_true", help="Plan only — no writes")
+    ap.add_argument("--limit", type=int, default=0, help="Process only the first N files (testing)")
+    ap.add_argument("--only", help="Comma-separated symbol filter, e.g. 'AAPL,MSFT,$VIX'")
+    ap.add_argument("--no-adjust", action="store_true", help="Fetch unadjusted bars (default: split-adjusted)")
+    args = ap.parse_args(argv)
+
+    adjusted = not args.no_adjust
+    api_key = get_api_key()
+    session = requests.Session()
+
+    data_dir = args.data_dir
+    if not os.path.isdir(data_dir):
+        logger.error("Data dir not found: %s (is the parquet_data submodule checked out?)", data_dir)
+        return 1
+
+    files = sorted(f for f in os.listdir(data_dir) if f.lower().endswith(".parquet"))
+    if args.only:
+        wanted = {s.strip() for s in args.only.split(",")}
+        files = [f for f in files if classify_symbol(f)[1] in wanted]
+    if args.limit:
+        files = files[: args.limit]
+
+    equities, indices, breadth = {}, {}, []
+    for f in files:
+        kind, base = classify_symbol(f)
+        if kind == "breadth":
+            breadth.append(base)
+        elif kind == "index":
+            indices[base] = os.path.join(data_dir, f)
+        else:
+            equities[base.upper()] = os.path.join(data_dir, f)
+
+    logger.info("Universe: %d equities, %d indices, %d breadth (skipped).",
+                len(equities), len(indices), len(breadth))
+
+    end_date = args.end or last_trading_day(session, api_key)
+    logger.info("Target end date: %s | adjusted=%s | dry_run=%s", end_date, adjusted, args.dry_run)
+
+    # Per-file last dates (to append only genuinely new rows).
+    eq_last: dict[str, pd.Timestamp | None] = {sym: read_last_date(p) for sym, p in equities.items()}
+
+    # ── Equities via grouped endpoint (one call per trading day) ──────────────
+    eq_updated = eq_skipped = 0
+    if equities:
+        if args.start:
+            grouped_start = args.start
+        else:
+            valid = [d for d in eq_last.values() if d is not None]
+            grouped_start = ((min(valid) + timedelta(days=1)).strftime("%Y-%m-%d")
+                             if valid else SEAM_DATE)
+        days = _business_days(grouped_start, end_date)
+        logger.info("Equities: fetching %d grouped day(s) from %s to %s.", len(days), grouped_start, end_date)
+
+        accum: dict[str, list[tuple[str, dict]]] = {sym: [] for sym in equities}
+        for i, ds in enumerate(days, 1):
+            hits = fetch_grouped_day(session, api_key, ds, adjusted)
+            for sym in equities:
+                bar = hits.get(sym)
+                if bar is not None:
+                    accum[sym].append((ds, bar))
+            if i % 10 == 0 or i == len(days):
+                logger.info("  grouped %d/%d days fetched.", i, len(days))
+
+        for sym, path in equities.items():
+            last = eq_last[sym]
+            rows = accum[sym]
+            if last is not None:
+                rows = [(ds, b) for ds, b in rows if pd.Timestamp(ds, tz="UTC").normalize() > last]
+            df = grouped_rows_to_df(rows)
+            added = append_and_write(path, df, args.dry_run)
+            if added:
+                eq_updated += 1
+            else:
+                eq_skipped += 1
+        logger.info("Equities done: %d updated, %d unchanged.", eq_updated, eq_skipped)
+
+    # ── Indices via per-ticker aggregates ─────────────────────────────────────
+    idx_updated = idx_skipped = idx_failed = 0
+    for base, path in indices.items():
+        poly_sym = normalize_ticker(base, "polygon")
+        last = read_last_date(path)
+        start = args.start or ((last + timedelta(days=1)).strftime("%Y-%m-%d") if last is not None else SEAM_DATE)
+        if start > end_date:
+            idx_skipped += 1
+            continue
+        rows = fetch_ticker_range(session, api_key, poly_sym, start, end_date, adjusted)
+        if not rows:
+            logger.warning("Index %s (%s): no bars from Polygon for %s..%s.", base, poly_sym, start, end_date)
+            idx_failed += 1
+            continue
+        df = bars_to_df(rows)
+        if last is not None:
+            df = df[df.index > last]
+        added = append_and_write(path, df, args.dry_run)
+        idx_updated += 1 if added else 0
+        idx_skipped += 0 if added else 1
+        if _RATE_LIMIT_SLEEP:
+            time.sleep(_RATE_LIMIT_SLEEP)
+    if indices:
+        logger.info("Indices done: %d updated, %d unchanged, %d failed.", idx_updated, idx_skipped, idx_failed)
+
+    if breadth:
+        logger.info("Breadth (#) frozen/skipped: %d files (Norgate-only, not on Polygon).", len(breadth))
+
+    logger.info("%sComplete. Equities updated=%d, indices updated=%d.",
+                "[DRY RUN] " if args.dry_run else "", eq_updated, idx_updated)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/polygon_daily_update.py
+++ b/scripts/polygon_daily_update.py
@@ -229,7 +229,19 @@ def last_trading_day(session, api_key, before: str | None = None) -> str:
 
 
 def _business_days(start: str, end: str) -> list[str]:
-    return [d.strftime("%Y-%m-%d") for d in pd.bdate_range(start=start, end=end)]
+    """Trading days in [start, end].
+
+    Prefers the NYSE calendar (skips market holidays like MLK Day, Thanksgiving)
+    when ``pandas_market_calendars`` is installed; otherwise falls back to
+    weekday-only ``bdate_range``. Holidays only cost a wasted empty API call under
+    the fallback, so the dependency is optional, not required.
+    """
+    try:
+        import pandas_market_calendars as mcal
+        sched = mcal.get_calendar("NYSE").schedule(start_date=start, end_date=end)
+        return [d.strftime("%Y-%m-%d") for d in sched.index]
+    except Exception:
+        return [d.strftime("%Y-%m-%d") for d in pd.bdate_range(start=start, end=end)]
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/scripts/polygon_daily_update.sh
+++ b/scripts/polygon_daily_update.sh
@@ -21,6 +21,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
+# Resolve the interpreter. Prefer the repo venv — the system `python3` may be too
+# new for the pinned deps (e.g. pandas_ta). Fall back to whatever `python` is on PATH.
+if [[ -x "$REPO_ROOT/.venv/bin/python" ]]; then
+    PY="$REPO_ROOT/.venv/bin/python"
+elif command -v python >/dev/null 2>&1; then
+    PY="python"
+else
+    PY="python3"
+fi
+
+# Capture the main-repo branch now, before any submodule checkout, so the
+# submodule-pointer push targets the right branch even under cron/detached HEAD.
+MAIN_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+[[ "$MAIN_BRANCH" == "HEAD" ]] && MAIN_BRANCH="main"
+
 LOG_DIR="$REPO_ROOT/logs"
 mkdir -p "$LOG_DIR"
 STAMP="$(date +%Y-%m-%d)"
@@ -31,24 +46,27 @@ log() { echo "$@" | tee -a "$LOG"; }
 log "=== polygon_daily_update ${STAMP} ==="
 
 # 1. Run the updater. On --dry-run nothing is written, so the commit step no-ops.
-python scripts/polygon_daily_update.py "$@" 2>&1 | tee -a "$LOG"
+"$PY" scripts/polygon_daily_update.py "$@" 2>&1 | tee -a "$LOG"
 
 # 2. Commit + push the submodule if data/ changed.
 cd "$REPO_ROOT/parquet_data"
 
-# Submodules are often in detached HEAD — land on a real branch before committing.
-git checkout master 2>/dev/null || git checkout main 2>/dev/null || true
+# Submodules are often in detached HEAD — land on a real branch before committing,
+# and remember which one so the push is explicit (not the ambiguous `HEAD`).
+SUB_BRANCH=""
+if git checkout master 2>/dev/null; then SUB_BRANCH="master"
+elif git checkout main 2>/dev/null; then SUB_BRANCH="main"; fi
 
 if [[ -n "$(git status --porcelain data/)" ]]; then
     COUNT="$(git status --porcelain data/ | wc -l | tr -d ' ')"
     git add data/
     git commit -m "chore: polygon daily update ${STAMP} (${COUNT} files)" | tee -a "$LOG"
-    git push origin HEAD | tee -a "$LOG"
+    git push origin "${SUB_BRANCH:-master}" | tee -a "$LOG"
 
     cd "$REPO_ROOT"
     git add parquet_data
     git commit -m "chore(submodule): bump parquet_data — daily update ${STAMP}" | tee -a "$LOG"
-    git push origin HEAD | tee -a "$LOG"
+    git push origin "$MAIN_BRANCH" | tee -a "$LOG"
     log "Pushed ${COUNT} updated parquet file(s) and bumped submodule pointer."
 else
     log "No parquet changes — nothing to commit."

--- a/scripts/polygon_daily_update.sh
+++ b/scripts/polygon_daily_update.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# polygon_daily_update.sh — daily cron wrapper for Issue #191.
+#
+# 1. Runs scripts/polygon_daily_update.py (writes new bars into parquet_data/data/).
+# 2. If the submodule changed, commits + pushes it, then bumps the submodule
+#    pointer in the main repo and pushes that too.
+#
+# Any args are passed through to the Python updater, e.g.:
+#     scripts/polygon_daily_update.sh --start 2026-04-23
+#     scripts/polygon_daily_update.sh --dry-run
+#
+# Suggested cron (07:00 local, after the prior US session has settled):
+#     0 7 * * 1-5  /path/to/july-backtester/scripts/polygon_daily_update.sh >> /path/to/cron.log 2>&1
+#
+# Requires: POLYGON_API_KEY in env or .env, git-lfs initialised in the submodule.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+LOG_DIR="$REPO_ROOT/logs"
+mkdir -p "$LOG_DIR"
+STAMP="$(date +%Y-%m-%d)"
+LOG="$LOG_DIR/polygon_daily_update_${STAMP}.log"
+
+log() { echo "$@" | tee -a "$LOG"; }
+
+log "=== polygon_daily_update ${STAMP} ==="
+
+# 1. Run the updater. On --dry-run nothing is written, so the commit step no-ops.
+python scripts/polygon_daily_update.py "$@" 2>&1 | tee -a "$LOG"
+
+# 2. Commit + push the submodule if data/ changed.
+cd "$REPO_ROOT/parquet_data"
+
+# Submodules are often in detached HEAD — land on a real branch before committing.
+git checkout master 2>/dev/null || git checkout main 2>/dev/null || true
+
+if [[ -n "$(git status --porcelain data/)" ]]; then
+    COUNT="$(git status --porcelain data/ | wc -l | tr -d ' ')"
+    git add data/
+    git commit -m "chore: polygon daily update ${STAMP} (${COUNT} files)" | tee -a "$LOG"
+    git push origin HEAD | tee -a "$LOG"
+
+    cd "$REPO_ROOT"
+    git add parquet_data
+    git commit -m "chore(submodule): bump parquet_data — daily update ${STAMP}" | tee -a "$LOG"
+    git push origin HEAD | tee -a "$LOG"
+    log "Pushed ${COUNT} updated parquet file(s) and bumped submodule pointer."
+else
+    log "No parquet changes — nothing to commit."
+fi
+
+log "=== done ${STAMP} ==="

--- a/scripts/polygon_new_listings.py
+++ b/scripts/polygon_new_listings.py
@@ -1,0 +1,152 @@
+"""
+polygon_new_listings.py — weekly IPO scan (Issue #191, §5).
+
+The daily updater (polygon_daily_update.py) only touches symbols that already
+have a Parquet file, so brand-new listings would never enter the universe.
+This script closes that gap on a weekly cadence:
+
+  1. Pull Polygon's active stock universe (/v3/reference/tickers, paginated).
+  2. Diff it against the equity Parquet files already in parquet_data/data/.
+  3. For each genuinely new ticker, fetch its full daily history and write a
+     new Parquet file in the canonical format.
+
+A new IPO has no usable history for momentum/MR strategies until it has 60–200
+bars, so weekly latency costs nothing — this is intentionally NOT in the daily
+hot path. Run it from its own weekly cron.
+
+Usage:
+    python scripts/polygon_new_listings.py                 # add new listings (full history)
+    python scripts/polygon_new_listings.py --since 2026-04-23   # cap history start
+    python scripts/polygon_new_listings.py --dry-run       # list new tickers, no writes
+    python scripts/polygon_new_listings.py --limit 25      # cap how many new files to create
+"""
+
+import os
+import sys
+import logging
+import argparse
+from datetime import datetime
+
+import requests
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, PROJECT_ROOT)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))  # so we can import the sibling script
+
+from polygon_daily_update import (  # noqa: E402
+    API_BASE, SEAM_DATE, DEFAULT_DATA_DIR,
+    classify_symbol, get_api_key, polygon_get, fetch_ticker_range,
+    bars_to_df, append_and_write, last_trading_day,
+)
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv(os.path.join(PROJECT_ROOT, ".env"))
+except ImportError:
+    pass
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger("polygon_new_listings")
+
+# Default earliest history to fetch for a brand-new file. Most IPOs are recent,
+# so this is just a floor; Polygon returns from the listing date onward anyway.
+DEFAULT_HISTORY_START = "2004-01-01"
+
+
+def fetch_active_equities(session, api_key: str) -> set[str]:
+    """Return the set of active common-stock tickers from Polygon reference data."""
+    tickers: set[str] = set()
+    path = "/v3/reference/tickers"
+    params = {"market": "stocks", "active": "true", "type": "CS", "limit": 1000, "order": "asc"}
+    page = 0
+    while path:
+        resp = polygon_get(session, api_key, path, params)
+        for row in resp.get("results", []) or []:
+            t = row.get("ticker")
+            if t:
+                tickers.add(t.upper())
+        page += 1
+        next_url = resp.get("next_url")
+        if not next_url:
+            break
+        # next_url is absolute and carries the cursor; strip base + re-attach apiKey via polygon_get.
+        path = next_url.replace(API_BASE, "")
+        params = None  # cursor already encoded in next_url
+        if page % 5 == 0:
+            logger.info("  reference: %d pages, %d tickers so far...", page, len(tickers))
+    logger.info("Polygon active common-stock universe: %d tickers (%d pages).", len(tickers), page)
+    return tickers
+
+
+def existing_equity_symbols(data_dir: str) -> set[str]:
+    """Uppercased set of equity symbols that already have a Parquet file."""
+    out: set[str] = set()
+    for f in os.listdir(data_dir):
+        if not f.lower().endswith(".parquet"):
+            continue
+        kind, base = classify_symbol(f)
+        if kind == "equity":
+            out.add(base.upper())
+    return out
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Weekly Polygon new-listings scan (#191)")
+    ap.add_argument("--data-dir", default=DEFAULT_DATA_DIR)
+    ap.add_argument("--since", default=DEFAULT_HISTORY_START,
+                    help=f"Earliest history date to fetch for new files (default {DEFAULT_HISTORY_START})")
+    ap.add_argument("--end", help="End date YYYY-MM-DD (default: last trading day)")
+    ap.add_argument("--dry-run", action="store_true", help="List new tickers only — no writes")
+    ap.add_argument("--limit", type=int, default=0, help="Cap how many new files to create (testing)")
+    ap.add_argument("--no-adjust", action="store_true", help="Fetch unadjusted bars (default: split-adjusted)")
+    args = ap.parse_args(argv)
+
+    adjusted = not args.no_adjust
+    api_key = get_api_key()
+    session = requests.Session()
+
+    if not os.path.isdir(args.data_dir):
+        logger.error("Data dir not found: %s (is the parquet_data submodule checked out?)", args.data_dir)
+        return 1
+
+    active = fetch_active_equities(session, api_key)
+    have = existing_equity_symbols(args.data_dir)
+    new_tickers = sorted(active - have)
+    logger.info("New listings to add: %d (active %d − existing %d).", len(new_tickers), len(active), len(have))
+
+    if not new_tickers:
+        logger.info("Universe already current — nothing to add.")
+        return 0
+
+    if args.limit:
+        new_tickers = new_tickers[: args.limit]
+
+    if args.dry_run:
+        logger.info("[DRY RUN] Would create %d files: %s%s",
+                    len(new_tickers), ", ".join(new_tickers[:20]),
+                    " ..." if len(new_tickers) > 20 else "")
+        return 0
+
+    end_date = args.end or last_trading_day(session, api_key)
+    created = failed = 0
+    for sym in new_tickers:
+        rows = fetch_ticker_range(session, api_key, sym, args.since, end_date, adjusted)
+        if not rows:
+            logger.warning("New ticker %s: no bars %s..%s — skipped.", sym, args.since, end_date)
+            failed += 1
+            continue
+        df = bars_to_df(rows)
+        path = os.path.join(args.data_dir, f"{sym}.parquet")
+        added = append_and_write(path, df, dry_run=False)
+        if added:
+            created += 1
+            logger.info("  + %s.parquet (%d bars, last %s)", sym, added, df.index.max().date())
+        else:
+            failed += 1
+
+    logger.info("New-listings scan complete: %d created, %d failed/empty.", created, failed)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_polygon_daily_update.py
+++ b/tests/test_polygon_daily_update.py
@@ -1,0 +1,307 @@
+"""Tests for the Polygon → Parquet daily updater + new-listings scan (#191).
+
+No network: Polygon HTTP is faked via a stub session. Parquet I/O is real
+(tmp_path), mirroring the csv_service test style.
+"""
+import os
+import sys
+
+import pandas as pd
+import pytest
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
+sys.path.insert(0, SCRIPTS_DIR)
+
+import polygon_daily_update as pdu  # noqa: E402
+import polygon_new_listings as pnl  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Fake Polygon HTTP
+# ──────────────────────────────────────────────────────────────────────────────
+class _FakeResp:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import requests
+            raise requests.exceptions.HTTPError(f"status {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+class _FakeSession:
+    """Routes GETs to canned payloads keyed by a substring of the URL path."""
+    def __init__(self, routes):
+        self.routes = routes
+        self.calls = []
+
+    def get(self, url, params=None, timeout=None):
+        self.calls.append(url)
+        for key, payload in self.routes.items():
+            if key in url:
+                return _FakeResp(payload)
+        return _FakeResp({"results": [], "resultsCount": 0})
+
+
+class _SequenceSession:
+    """Returns canned payloads in order, one per GET — for pagination tests."""
+    def __init__(self, payloads):
+        self._payloads = list(payloads)
+        self.calls = []
+
+    def get(self, url, params=None, timeout=None):
+        self.calls.append(url)
+        payload = self._payloads[min(len(self.calls) - 1, len(self._payloads) - 1)]
+        return _FakeResp(payload)
+
+
+def _bar(o, h, l, c, v, t_ms):
+    return {"o": o, "h": h, "l": l, "c": c, "v": v, "t": t_ms}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# classify_symbol
+# ──────────────────────────────────────────────────────────────────────────────
+class TestClassifySymbol:
+    def test_equity(self):
+        assert pdu.classify_symbol("AAPL.parquet") == ("equity", "AAPL")
+
+    def test_index_dollar(self):
+        assert pdu.classify_symbol("$VIX.parquet") == ("index", "$VIX")
+
+    def test_breadth_hash(self):
+        assert pdu.classify_symbol("#AMEXAD.parquet") == ("breadth", "#AMEXAD")
+
+    def test_no_extension(self):
+        assert pdu.classify_symbol("MSFT") == ("equity", "MSFT")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Index symbol mapping (normalize_ticker integration)
+# ──────────────────────────────────────────────────────────────────────────────
+class TestIndexMapping:
+    def test_dollar_vix_maps_to_polygon(self):
+        from helpers.ticker_normalizer import normalize_ticker
+        assert normalize_ticker("$VIX", "polygon") == "I:VIX"
+
+    def test_equity_unchanged(self):
+        from helpers.ticker_normalizer import normalize_ticker
+        assert normalize_ticker("AAPL", "polygon") == "AAPL"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Frame builders
+# ──────────────────────────────────────────────────────────────────────────────
+class TestFrameBuilders:
+    def test_bars_to_df_columns_and_index(self):
+        ts = int(pd.Timestamp("2026-04-23", tz="UTC").timestamp() * 1000)
+        df = pdu.bars_to_df([_bar(10, 12, 9, 11, 1000, ts)])
+        assert list(df.columns) == ["Open", "High", "Low", "Close", "Volume"]
+        assert df.index[0] == pd.Timestamp("2026-04-23", tz="UTC")
+        assert df.iloc[0]["Close"] == 11
+
+    def test_bars_to_df_empty(self):
+        assert pdu.bars_to_df([]).empty
+
+    def test_grouped_rows_to_df(self):
+        rows = [("2026-04-23", {"o": 1, "h": 2, "l": 0.5, "c": 1.5, "v": 100})]
+        df = pdu.grouped_rows_to_df(rows)
+        assert df.index[0] == pd.Timestamp("2026-04-23", tz="UTC")
+        assert df.iloc[0]["Volume"] == 100
+        assert list(df.columns) == ["Open", "High", "Low", "Close", "Volume"]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Parquet append / dedup round-trip
+# ──────────────────────────────────────────────────────────────────────────────
+class TestAppendAndWrite:
+    def _existing(self, tmp_path):
+        idx = pd.to_datetime(["2026-04-21", "2026-04-22"], utc=True)
+        df = pd.DataFrame({"Open": [1, 2], "High": [1, 2], "Low": [1, 2],
+                           "Close": [1, 2], "Volume": [10, 20]}, index=idx)
+        df.index.name = "Datetime"
+        p = os.path.join(tmp_path, "AAPL.parquet")
+        df.to_parquet(p)
+        return p
+
+    def test_appends_new_rows(self, tmp_path):
+        p = self._existing(tmp_path)
+        new = pd.DataFrame({"Open": [3], "High": [3], "Low": [3], "Close": [3], "Volume": [30]},
+                           index=pd.to_datetime(["2026-04-23"], utc=True))
+        added = pdu.append_and_write(p, new, dry_run=False)
+        assert added == 1
+        out = pd.read_parquet(p)
+        assert len(out) == 3
+        assert out.index.max() == pd.Timestamp("2026-04-23", tz="UTC")
+
+    def test_dedup_keeps_last(self, tmp_path):
+        p = self._existing(tmp_path)
+        # Re-send 2026-04-22 with a corrected close + a genuinely new day.
+        new = pd.DataFrame({"Open": [9, 3], "High": [9, 3], "Low": [9, 3], "Close": [99, 3], "Volume": [9, 30]},
+                           index=pd.to_datetime(["2026-04-22", "2026-04-23"], utc=True))
+        added = pdu.append_and_write(p, new, dry_run=False)
+        out = pd.read_parquet(p)
+        assert len(out) == 3                      # not 4 — the dup collapsed
+        assert out.loc[pd.Timestamp("2026-04-22", tz="UTC"), "Close"] == 99  # kept last
+        assert added == 1
+
+    def test_dry_run_does_not_write(self, tmp_path):
+        p = self._existing(tmp_path)
+        new = pd.DataFrame({"Open": [3], "High": [3], "Low": [3], "Close": [3], "Volume": [30]},
+                           index=pd.to_datetime(["2026-04-23"], utc=True))
+        added = pdu.append_and_write(p, new, dry_run=True)
+        assert added == 1                          # reports what it WOULD add
+        assert len(pd.read_parquet(p)) == 2        # but file unchanged
+
+    def test_empty_new_df_noop(self, tmp_path):
+        p = self._existing(tmp_path)
+        assert pdu.append_and_write(p, pd.DataFrame(), dry_run=False) == 0
+
+    def test_creates_new_file(self, tmp_path):
+        p = os.path.join(tmp_path, "NEWCO.parquet")
+        new = pd.DataFrame({"Open": [3], "High": [3], "Low": [3], "Close": [3], "Volume": [30]},
+                           index=pd.to_datetime(["2026-04-23"], utc=True))
+        added = pdu.append_and_write(p, new, dry_run=False)
+        assert added == 1 and os.path.exists(p)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# read_last_date
+# ──────────────────────────────────────────────────────────────────────────────
+class TestReadLastDate:
+    def test_returns_max(self, tmp_path):
+        idx = pd.to_datetime(["2026-04-20", "2026-04-22", "2026-04-21"], utc=True)
+        df = pd.DataFrame({"Close": [1, 2, 3]}, index=idx)
+        p = os.path.join(tmp_path, "X.parquet")
+        df.to_parquet(p)
+        assert pdu.read_last_date(p) == pd.Timestamp("2026-04-22", tz="UTC")
+
+    def test_missing_file_none(self, tmp_path):
+        assert pdu.read_last_date(os.path.join(tmp_path, "nope.parquet")) is None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Polygon fetchers (faked HTTP)
+# ──────────────────────────────────────────────────────────────────────────────
+class TestFetchers:
+    def test_fetch_grouped_day_filters_and_maps(self):
+        sess = _FakeSession({"grouped": {"resultsCount": 2, "results": [
+            {"T": "AAPL", "o": 1, "h": 2, "l": 0.5, "c": 1.5, "v": 100},
+            {"T": "msft", "o": 3, "h": 4, "l": 2.5, "c": 3.5, "v": 200},
+        ]}})
+        hits = pdu.fetch_grouped_day(sess, "KEY", "2026-04-23", adjusted=True)
+        assert set(hits) == {"AAPL", "MSFT"}       # upper-cased keys
+        assert hits["AAPL"]["c"] == 1.5
+
+    def test_fetch_grouped_day_holiday_empty(self):
+        sess = _FakeSession({"grouped": {"resultsCount": 0, "results": []}})
+        assert pdu.fetch_grouped_day(sess, "KEY", "2026-04-25", adjusted=True) == {}
+
+    def test_fetch_ticker_range(self):
+        sess = _FakeSession({"range": {"results": [_bar(1, 2, 0.5, 1.5, 10, 1)]}})
+        rows = pdu.fetch_ticker_range(sess, "KEY", "I:VIX", "2026-04-23", "2026-04-30", adjusted=True)
+        assert len(rows) == 1 and rows[0]["c"] == 1.5
+
+    def test_adjusted_param_passed(self):
+        sess = _FakeSession({"grouped": {"resultsCount": 0, "results": []}})
+        pdu.fetch_grouped_day(sess, "KEY", "2026-04-23", adjusted=True)
+        # The adjusted flag should ride along in params (url recorded; params separate)
+        assert sess.calls  # at least one call made
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _business_days
+# ──────────────────────────────────────────────────────────────────────────────
+class TestBusinessDays:
+    def test_excludes_weekend(self):
+        # 2026-04-24 is a Friday; 25/26 weekend; 27 Monday.
+        days = pdu._business_days("2026-04-24", "2026-04-27")
+        assert days == ["2026-04-24", "2026-04-27"]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# New-listings diff
+# ──────────────────────────────────────────────────────────────────────────────
+class TestNewListings:
+    def test_existing_equity_symbols_excludes_index_and_breadth(self, tmp_path):
+        for name in ["AAPL.parquet", "$VIX.parquet", "#AMEXAD.parquet", "msft.parquet"]:
+            pd.DataFrame({"Close": [1]}, index=pd.to_datetime(["2026-04-22"], utc=True)).to_parquet(
+                os.path.join(tmp_path, name))
+        have = pnl.existing_equity_symbols(str(tmp_path))
+        assert have == {"AAPL", "MSFT"}            # $ and # excluded, case-folded
+
+    def test_fetch_active_equities_paginates(self):
+        sess = _SequenceSession([
+            {"results": [{"ticker": "AAA"}, {"ticker": "BBB"}],
+             "next_url": pdu.API_BASE + "/v3/reference/tickers?cursor=page2"},
+            {"results": [{"ticker": "CCC"}], "next_url": None},
+        ])
+        got = pnl.fetch_active_equities(sess, "KEY")
+        assert got == {"AAA", "BBB", "CCC"}
+        assert len(sess.calls) == 2  # exactly two pages, no infinite loop
+
+    def test_new_minus_existing(self):
+        active = {"AAA", "BBB", "CCC"}
+        have = {"AAA"}
+        assert sorted(active - have) == ["BBB", "CCC"]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# main() orchestration (fetchers monkeypatched — no network; real parquet I/O)
+# ──────────────────────────────────────────────────────────────────────────────
+class TestMainOrchestration:
+    def _seed(self, tmp_path):
+        idx = pd.to_datetime(["2026-04-22"], utc=True)
+        for name in ["AAPL.parquet", "$VIX.parquet", "#AMEXAD.parquet"]:
+            df = pd.DataFrame({"Open": [1], "High": [1], "Low": [1], "Close": [1], "Volume": [10]}, index=idx)
+            df.index.name = "Datetime"
+            df.to_parquet(os.path.join(tmp_path, name))
+
+    def test_equity_index_updated_breadth_skipped(self, tmp_path, monkeypatch):
+        self._seed(tmp_path)
+
+        monkeypatch.setattr(pdu, "get_api_key", lambda: "KEY")
+        monkeypatch.setattr(pdu, "last_trading_day", lambda *a, **k: "2026-04-24")
+
+        def fake_grouped(session, key, ds, adjusted):
+            # AAPL trades both new days; nothing else equity in our set.
+            return {"AAPL": {"o": 5, "h": 6, "l": 4, "c": 5.5, "v": 999}}
+
+        def fake_range(session, key, sym, start, end, adjusted):
+            assert sym == "I:VIX"  # $VIX must be normalized for Polygon
+            ts = int(pd.Timestamp("2026-04-23", tz="UTC").timestamp() * 1000)
+            return [_bar(20, 21, 19, 20.5, 0, ts)]
+
+        monkeypatch.setattr(pdu, "fetch_grouped_day", fake_grouped)
+        monkeypatch.setattr(pdu, "fetch_ticker_range", fake_range)
+
+        rc = pdu.main(["--data-dir", str(tmp_path), "--start", "2026-04-23", "--end", "2026-04-24"])
+        assert rc == 0
+
+        aapl = pd.read_parquet(os.path.join(tmp_path, "AAPL.parquet"))
+        assert aapl.index.max() == pd.Timestamp("2026-04-24", tz="UTC")
+        assert len(aapl) == 3  # 04-22 seed + 04-23 + 04-24
+
+        vix = pd.read_parquet(os.path.join(tmp_path, "$VIX.parquet"))
+        assert pd.Timestamp("2026-04-23", tz="UTC") in vix.index
+
+        breadth = pd.read_parquet(os.path.join(tmp_path, "#AMEXAD.parquet"))
+        assert len(breadth) == 1  # untouched — frozen
+
+    def test_dry_run_writes_nothing(self, tmp_path, monkeypatch):
+        self._seed(tmp_path)
+        monkeypatch.setattr(pdu, "get_api_key", lambda: "KEY")
+        monkeypatch.setattr(pdu, "last_trading_day", lambda *a, **k: "2026-04-24")
+        monkeypatch.setattr(pdu, "fetch_grouped_day",
+                            lambda *a, **k: {"AAPL": {"o": 5, "h": 6, "l": 4, "c": 5.5, "v": 999}})
+        monkeypatch.setattr(pdu, "fetch_ticker_range", lambda *a, **k: [])
+
+        rc = pdu.main(["--data-dir", str(tmp_path), "--start", "2026-04-23",
+                       "--end", "2026-04-24", "--dry-run"])
+        assert rc == 0
+        aapl = pd.read_parquet(os.path.join(tmp_path, "AAPL.parquet"))
+        assert len(aapl) == 1  # dry-run: seed file unchanged


### PR DESCRIPTION
## Summary

Implements the daily Polygon → Parquet pipeline from #191, replacing the retired Norgate Data Updater. Files are written in the exact format `data_provider: "parquet"` already reads (`Datetime` UTC index, `[Open, High, Low, Close, Volume]`), so the backtester keeps running with **zero API calls at run time**.

Closes #191.

## What's included

| File | Purpose |
|------|---------|
| `scripts/polygon_daily_update.py` | Daily updater. **Equities** via the grouped endpoint (one call per trading day — ~46 calls for the whole backfill, not 35k). **`$` indices** via per-ticker aggs, mapped to `I:` through `helpers.ticker_normalizer.normalize_ticker`. **`#` breadth** files frozen/skipped (Norgate-only, not on Polygon). Append-only with dedup-on-index. |
| `scripts/polygon_new_listings.py` | Weekly IPO scan — diffs Polygon's active common-stock universe against existing files and backfills any new tickers. |
| `scripts/polygon_daily_update.sh` | Cron wrapper — runs the updater, commits + pushes the submodule, bumps the pointer in the main repo. |
| `tests/test_polygon_daily_update.py` | **26 tests**, no network (mocked Polygon) + real tmp parquet round-trips. |

## Design decisions (per your answers on #191)

- **Split-adjusted only** (`adjusted=true`), no dividend pull — the seam at 2026-04-22 stays clean. `--no-adjust` available if ever needed.
- **Daily bars only** — grouped endpoint returns daily by default, no timespan param.
- **Weekly IPO cadence** — separate script, off the daily hot path.
- **`#` breadth frozen** — confirmed no active strategy depends on them.
- Backfill window is short (~46 trading days from `2026-04-23`), so any Polygon plan works.

## Flags

```
polygon_daily_update.py  [--start YYYY-MM-DD] [--end YYYY-MM-DD] [--dry-run]
                         [--limit N] [--only AAPL,MSFT,$VIX] [--no-adjust]
polygon_new_listings.py  [--since YYYY-MM-DD] [--end ...] [--dry-run] [--limit N]
```

## Testing

- 26/26 unit tests pass — `main()` orchestration (equity updated / index normalized / breadth skipped), append + dedup-keep-last, `--dry-run` writes nothing, grouped parsing, reference pagination (no infinite loop), `read_last_date`, business-day calendar.
- Two bugs were caught + fixed while writing the tests: a `Series.normalize()` → `Series.dt.normalize()` error in the bar builder, and a Windows cp1252 crash in `--help` (a `→` in the argparse description).

## Operational step (not run in this PR)

The live ~35k-file backfill + submodule push needs the `parquet_data` submodule checked out and `POLYGON_API_KEY` set — it's a deliberate one-time run, not part of CI:

```bash
python scripts/polygon_daily_update.py --start 2026-04-23   # ~46 grouped calls
scripts/polygon_daily_update.sh                             # or: run + auto-commit/push the submodule
```

Then schedule `scripts/polygon_daily_update.sh` daily and `scripts/polygon_new_listings.py` weekly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
