### PR TITLE
fix(plotting): auto-switch to log Y-axis when equity range exceeds 10× (#201)

### DIFF
--- a/tests/test_log_scale_plots.py
+++ b/tests/test_log_scale_plots.py
@@ -1,0 +1,109 @@
+"""tests/test_log_scale_plots.py
+
+Tests that plot_benchmark_comparison and plot_mc_fan auto-switch to log Y-axis
+when equity range exceeds 10x, and stay on linear scale for normal ranges.
+"""
+
+import os
+import sys
+
+import matplotlib
+matplotlib.use('Agg')  # non-interactive backend — must be set before pyplot import
+
+import numpy as np
+import pandas as pd
+import pytest
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from trade_analyzer.plotting import plot_benchmark_comparison, plot_mc_fan
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_equity(start: float, end: float, n: int = 50) -> pd.Series:
+    dates = pd.date_range('2010-01-01', periods=n, freq='B')
+    values = np.linspace(start, end, n)
+    return pd.Series(values, index=dates)
+
+
+def _make_benchmark_df(equity: pd.Series) -> pd.DataFrame:
+    """Benchmark that exactly tracks the equity (normalisation test doesn't matter here)."""
+    return pd.DataFrame({'Benchmark_Price': equity.values * 1.1}, index=equity.index)
+
+
+def _make_mc_paths(initial: float, final_median: float, n_trades: int = 30, n_sims: int = 100) -> pd.DataFrame:
+    """Build a DataFrame of MC equity paths (shape: n_trades x n_sims)."""
+    rng = np.random.default_rng(42)
+    paths = np.linspace(initial, final_median, n_trades)[:, None] + rng.normal(0, initial * 0.05, (n_trades, n_sims))
+    paths = np.clip(paths, 1, None)
+    return pd.DataFrame(paths)
+
+
+# ---------------------------------------------------------------------------
+# plot_benchmark_comparison — Y-axis scale
+# ---------------------------------------------------------------------------
+
+class TestBenchmarkComparisonLogScale:
+    def test_linear_scale_for_small_range(self):
+        """Range < 10× → linear scale (no change to existing behaviour)."""
+        equity = _make_equity(100_000, 300_000)  # 3× — linear
+        bdf = _make_benchmark_df(equity)
+        fig = plot_benchmark_comparison(equity, bdf, 'SPY')
+        ax = fig.axes[0]
+        assert ax.get_yscale() == 'linear'
+
+    def test_log_scale_for_large_range(self):
+        """Range > 10× → log scale auto-applied."""
+        equity = _make_equity(100_000, 1_100_000)  # 11× — log
+        bdf = _make_benchmark_df(equity)
+        fig = plot_benchmark_comparison(equity, bdf, 'SPY')
+        ax = fig.axes[0]
+        assert ax.get_yscale() == 'log'
+
+    def test_boundary_at_exactly_10x_stays_linear(self):
+        """Exactly 10× is NOT > 10, so stays linear."""
+        equity = _make_equity(100_000, 1_000_000)  # exactly 10× (min/max = 10.0)
+        bdf = _make_benchmark_df(equity)
+        fig = plot_benchmark_comparison(equity, bdf, 'SPY')
+        ax = fig.axes[0]
+        assert ax.get_yscale() == 'linear'
+
+    def test_returns_figure_on_large_range(self):
+        """Function must not raise and must return a Figure for large compounding runs."""
+        equity = _make_equity(100_000, 2_000_000)
+        bdf = _make_benchmark_df(equity)
+        import matplotlib.pyplot as plt
+        fig = plot_benchmark_comparison(equity, bdf, 'SPY')
+        assert isinstance(fig, plt.Figure)
+
+
+# ---------------------------------------------------------------------------
+# plot_mc_fan — Y-axis scale
+# ---------------------------------------------------------------------------
+
+class TestMcFanLogScale:
+    def test_linear_scale_for_small_range(self):
+        """p95/p5 ratio < 10 → linear scale."""
+        paths = _make_mc_paths(100_000, 300_000)
+        fig = plot_mc_fan(paths, initial_equity=100_000)
+        ax = fig.axes[0]
+        assert ax.get_yscale() == 'linear'
+
+    def test_log_scale_for_large_range(self):
+        """p95/p5 ratio > 10 → log scale auto-applied."""
+        paths = _make_mc_paths(100_000, 1_500_000)
+        fig = plot_mc_fan(paths, initial_equity=100_000)
+        ax = fig.axes[0]
+        assert ax.get_yscale() == 'log'
+
+    def test_returns_figure_on_large_range(self):
+        """Function must not raise and must return a Figure for large MC fans."""
+        import matplotlib.pyplot as plt
+        paths = _make_mc_paths(100_000, 2_000_000)
+        fig = plot_mc_fan(paths, initial_equity=100_000)
+        assert isinstance(fig, plt.Figure)

--- a/trade_analyzer/plotting.py
+++ b/trade_analyzer/plotting.py
@@ -465,7 +465,12 @@ def plot_benchmark_comparison(
                         where=(eq_final >= bp_norm), color=T['positive'], alpha=0.08)
         ax.fill_between(eq_final.index, bp_norm, eq_final,
                         where=(eq_final < bp_norm), color=T['negative'], alpha=0.08)
-        _fmt_dollar(ax)
+        use_log = eq_final.max() / max(eq_final.min(), 1) > 10
+        if use_log:
+            ax.set_yscale('log')
+            ax.yaxis.set_major_formatter(mtick.FuncFormatter(lambda v, _: f'${v:,.0f}'))
+        else:
+            _fmt_dollar(ax)
         ax.legend()
         _style_ax(ax, title=title, xlabel='Date', ylabel='Portfolio Value ($)')
         fig.autofmt_xdate(rotation=25, ha='right')
@@ -581,7 +586,13 @@ def plot_mc_fan(
         ax.axhline(initial_equity, color=T['neutral'], linestyle=':', linewidth=1.0,
                    label=f'Initial (${initial_equity:,.0f})')
 
-        _fmt_dollar(ax)
+        p5_pos_min = p5[p5 > 0].min() if (p5 > 0).any() else initial_equity
+        use_log = p95.max() / max(p5_pos_min, 1) > 10
+        if use_log:
+            ax.set_yscale('log')
+            ax.yaxis.set_major_formatter(mtick.FuncFormatter(lambda v, _: f'${v:,.0f}'))
+        else:
+            _fmt_dollar(ax)
         ax.legend(loc='upper left')
         _style_ax(ax, title=f"{title} ({n_sims:,} sims)",
                   xlabel='Trade #', ylabel='Simulated Equity ($)')


### PR DESCRIPTION
## Summary

- `plot_benchmark_comparison()` and `plot_mc_fan()` in `trade_analyzer/plotting.py` were hardcoded to linear Y-axis via `_fmt_dollar(ax)`, causing hockey-stick distortion on any backtest that compounds more than ~10× (early years compress to a flat line, all movement appears as a right-edge spike).
- Both functions now auto-detect when the equity range exceeds 10× and switch to log scale with a dollar formatter. Linear scale is completely unchanged for all ≤10× return ranges — zero regression for normal strategies.
- 7 new tests in `tests/test_log_scale_plots.py` verify linear/log/boundary behaviour for both functions.

## Test plan

- [x] `tests/test_log_scale_plots.py` — 7 tests, all green
- [x] Range ≤ 10× → `ax.get_yscale() == 'linear'` (no change)
- [x] Range > 10× → `ax.get_yscale() == 'log'`
- [x] Exactly 10× boundary stays on linear (strict `> 10` guard)
- [x] Functions return a valid `Figure` on large compounding input (no exception)

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)